### PR TITLE
role/create-lxc: Add ability to use a token for Proxmox API auth

### DIFF
--- a/roles/create-lxc/README.md
+++ b/roles/create-lxc/README.md
@@ -99,6 +99,8 @@ proxmox_node: <node_name>           # (Required)
 proxmox_api_host: <node_ip>         # (Required)
 proxmox_api_user: <node_user@realm> # (Required)
 proxmox_api_password: <pwd>         # (Required)
+proxmox_api_token_id: <id>          # (Required)
+proxmox_api_token_secret: <secret>  # (Required)
 ```
 
 Dependencies

--- a/roles/create-lxc/tasks/create.yml
+++ b/roles/create-lxc/tasks/create.yml
@@ -3,88 +3,112 @@
 #   - https://github.com/UdelaRInterior/ansible-role-proxmox-create-lxc/blob/master/tasks/main.yml
 #   - https://github.com/maxhoesel-ansible/ansible-collection-proxmox
 - name: "Ensure LXC '{{ lxc_hostname }}' ({{ lxc_vmid }}) is present."
-  community.proxmox.proxmox:
-    node: "{{ proxmox_node }}"
-    api_host: "{{ proxmox_api_host }}"
-    api_user: "{{ proxmox_api_user }}"
-    api_password: "{{ proxmox_api_password }}"
+  block:
+    - name: "Ensure LXC '{{ lxc_hostname }}' ({{ lxc_vmid }}) is present via password."
+      community.proxmox.proxmox:
+        api_password: "{{ proxmox_api_password }}"
+      when: "proxmox_is_password_setup"
 
-    # Set main LXC info
-    state: present
-    vmid: "{{ lxc_vmid }}"
-    hostname: "{{ lxc_hostname }}"
-    password: "{{ lxc_password }}"
-    ostemplate: "{{ lxc_template_storage }}:vztmpl/{{ lxc_template }}"
-    unprivileged: "{{ lxc_unprivileged }}"
-    update: true
+    - name: "Ensure LXC '{{ lxc_hostname }}' ({{ lxc_vmid }}) is present via token."
+      community.proxmox.proxmox:
+        api_token_id: "{{ proxmox_api_token_id }}"
+        api_token_secret: "{{ proxmox_api_token_secret }}"
+      when: "proxmox_is_token_setup"
+  module_defaults:
+    community.proxmox.proxmox:
+      node: "{{ proxmox_node }}"
+      api_host: "{{ proxmox_api_host }}"
+      api_user: "{{ proxmox_api_user }}"
 
-    # Set hardware info
-    cores: "{{ lxc_cores }}"
-    memory: "{{ lxc_memory }}"
-    swap: "{{ lxc_swap }}"
-    features: "{{ lxc_features }}"
+      # Set main LXC info
+      state: present
+      vmid: "{{ lxc_vmid }}"
+      hostname: "{{ lxc_hostname }}"
+      password: "{{ lxc_password }}"
+      ostemplate: "{{ lxc_template_storage }}:vztmpl/{{ lxc_template }}"
+      unprivileged: "{{ lxc_unprivileged }}"
+      update: true
 
-    # Set disk info
-    disk_volume:
-      storage: "{{ lxc_disk_storage }}"
-      size: "{{ lxc_disk_size }}"
-    # TODO: Add more mount types other than bind mounts.
-    mounts: >-
-      { {%- for item in lxc_mounts -%}
-        "{{ item.id }}": "{{ item.bind }},mp={{ item.mount }}",
-      {%- endfor -%} }
+      # Set hardware info
+      cores: "{{ lxc_cores }}"
+      memory: "{{ lxc_memory }}"
+      swap: "{{ lxc_swap }}"
+      features: "{{ lxc_features }}"
 
-    # Set network interfaces
-    netif: >-
-      { {%- for item in lxc_network -%}
-        "{{ item.id }}":"name={{ item.name }},bridge={{ item.bridge | default('vmbr0') }},{% if (item.ip4 is defined) %}ip={{ item.ip4 }}{% endif %}{% if (item.netmask4 is defined) %}/{{ item.netmask4 }},{% else %},{% endif %}{% if (item.gw4 is defined) %}gw={{ item.gw4 }},{% endif %}{% if (item.ip6 is defined) %}ip6={{ item.ip6 }}{% endif %}{% if (item.netmask6 is defined) %}/{{ item.netmask6 }},{% else %},{% endif %}{% if (item.gw6 is defined) %}gw6={{ item.gw6 }},{% endif %}{% if (item.firewall is defined and item.firewall) %}firewall=1,{% endif %}{% if (item.vlan_tag is defined) %}tag={{ item.vlan_tag }}{% endif %}",
-      {%- endfor -%} }
+      # Set disk info
+      disk_volume:
+        storage: "{{ lxc_disk_storage }}"
+        size: "{{ lxc_disk_size }}"
+      # TODO: Add more mount types other than bind mounts.
+      mounts: >-
+        { {%- for item in lxc_mounts -%}
+          "{{ item.id }}": "{{ item.bind }},mp={{ item.mount }}",
+        {%- endfor -%} }
 
-    # Set boot options
-    onboot: "{{ lxc_onboot }}"
-    # TODO: Change lxc_startup option to lxc_boot_order
-    startup: "{{ lxc_startup if (lxc_startup is defined and lxc_startup | length > 0) else omit }}"
+      # Set network interfaces
+      netif: >-
+        { {%- for item in lxc_network -%}
+          "{{ item.id }}":"name={{ item.name }},bridge={{ item.bridge | default('vmbr0') }},{% if (item.ip4 is defined) %}ip={{ item.ip4 }}{% endif %}{% if (item.netmask4 is defined) %}/{{ item.netmask4 }},{% else %},{% endif %}{% if (item.gw4 is defined) %}gw={{ item.gw4 }},{% endif %}{% if (item.ip6 is defined) %}ip6={{ item.ip6 }}{% endif %}{% if (item.netmask6 is defined) %}/{{ item.netmask6 }},{% else %},{% endif %}{% if (item.gw6 is defined) %}gw6={{ item.gw6 }},{% endif %}{% if (item.firewall is defined and item.firewall) %}firewall=1,{% endif %}{% if (item.vlan_tag is defined) %}tag={{ item.vlan_tag }}{% endif %}",
+        {%- endfor -%} }
 
-    # Set SSH pubkey for remote access
-    # TODO: Add SSH key of the proxmox node for future management
-    pubkey: "{{ lookup('file', lxc_pubkey) if (lxc_pubkey is defined and lxc_pubkey | length > 0) else omit }}"
+      # Set boot options
+      onboot: "{{ lxc_onboot }}"
+      # TODO: Change lxc_startup option to lxc_boot_order
+      startup: "{{ lxc_startup if (lxc_startup is defined and lxc_startup | length > 0) else omit }}"
 
-    # Set additional info
-    nameserver: "{{ lxc_nameserver if (lxc_nameserver is defined and lxc_nameserver | length > 0) else omit }}"
-    timezone: "{{ lxc_timezone if (lxc_timezone is defined and lxc_timezone | length > 0) else omit }}"
-    tags: "{{ lxc_tags + ['ansible'] }}"
+      # Set SSH pubkey for remote access
+      # TODO: Add SSH key of the proxmox node for future management
+      pubkey: "{{ lookup('file', lxc_pubkey) if (lxc_pubkey is defined and lxc_pubkey | length > 0) else omit }}"
 
-    # Set the description
-    # TODO: Include all IPs in the description.
-    description: |
-      <div>
-        <h2 align="center" style="font-size: 24px; margin: 20px 0">
-            {{ lxc_appname }} LXC
-        </h2>
-        <p style="margin: 16px 0">
-            <strong>Note: </strong>This Proxmox LXC container is managed by Ansible.
-            Please contact your system administrators to ensure that any changes you
-            make here are not lost.
-        </p>
-        <ul>
-          <li><strong>Hostname: </strong>{{ lxc_hostname }}</li>
-          <li><strong>CPUs: </strong>{{ lxc_cores }}</li>
-          <li><strong>RAM: </strong>{{ lxc_memory }}MB</li>
-          <li><strong>Storage: </strong>{{ lxc_disk_size }}GB</li>
-        </ul>
-      </div>
+      # Set additional info
+      nameserver: "{{ lxc_nameserver if (lxc_nameserver is defined and lxc_nameserver | length > 0) else omit }}"
+      timezone: "{{ lxc_timezone if (lxc_timezone is defined and lxc_timezone | length > 0) else omit }}"
+      tags: "{{ lxc_tags + ['ansible'] }}"
+
+      # Set the description
+      # TODO: Include all IPs in the description.
+      description: |
+        <div>
+          <h2 align="center" style="font-size: 24px; margin: 20px 0">
+              {{ lxc_appname }} LXC
+          </h2>
+          <p style="margin: 16px 0">
+              <strong>Note: </strong>This Proxmox LXC container is managed by Ansible.
+              Please contact your system administrators to ensure that any changes you
+              make here are not lost.
+          </p>
+          <ul>
+            <li><strong>Hostname: </strong>{{ lxc_hostname }}</li>
+            <li><strong>CPUs: </strong>{{ lxc_cores }}</li>
+            <li><strong>RAM: </strong>{{ lxc_memory }}MB</li>
+            <li><strong>Storage: </strong>{{ lxc_disk_size }}GB</li>
+          </ul>
+        </div>
 
 - name: Ensure LXC exists after its creation.
   block:
     - name: "Get status of LXC '{{ lxc_vmid }}'."
-      community.proxmox.proxmox_vm_info:
-        node: "{{ proxmox_node }}"
-        api_host: "{{ proxmox_api_host }}"
-        api_user: "{{ proxmox_api_user }}"
-        api_password: "{{ proxmox_api_password }}"
-        vmid: "{{ lxc_vmid }}"
-      register: _proxmox_lxc_status
-      changed_when: false
+      block:
+        - name: "Get status of LXC '{{ lxc_vmid }}' via password."
+          community.proxmox.proxmox_vm_info:
+            api_password: "{{ proxmox_api_password }}"
+          register: _proxmox_lxc_status
+          changed_when: false
+          when: "proxmox_is_password_setup"
+
+        - name: "Get status of LXC '{{ lxc_vmid }}' via token."
+          community.proxmox.proxmox_vm_info:
+            api_token_id: "{{ proxmox_api_token_id }}"
+            api_token_secret: "{{ proxmox_api_token_secret }}"
+          register: _proxmox_lxc_status
+          changed_when: false
+          when: "proxmox_is_token_setup"
+      module_defaults:
+        community.proxmox.proxmox_vm_info:
+          node: "{{ proxmox_node }}"
+          api_host: "{{ proxmox_api_host }}"
+          api_user: "{{ proxmox_api_user }}"
+          vmid: "{{ lxc_vmid }}"
 
     - name: "Fail if the LXC does not exists after its creation."
       ansible.builtin.fail:
@@ -92,10 +116,21 @@
       when: "_proxmox_lxc_status.proxmox_vms | length == 0 | bool"
 
 - name: "Ensure LXC '{{ lxc_hostname }}' ({{ lxc_vmid }}) is running."
-  community.proxmox.proxmox:
-    node: "{{ proxmox_node }}"
-    api_host: "{{ proxmox_api_host }}"
-    api_user: "{{ proxmox_api_user }}"
-    api_password: "{{ proxmox_api_password }}"
-    vmid: "{{ lxc_vmid }}"
-    state: started
+  block:
+    - name: "Ensure LXC '{{ lxc_hostname }}' ({{ lxc_vmid }}) is running via password."
+      community.proxmox.proxmox:
+        api_password: "{{ proxmox_api_password }}"
+      when: "proxmox_is_password_setup"
+
+    - name: "Ensure LXC '{{ lxc_hostname }}' ({{ lxc_vmid }}) is running via token."
+      community.proxmox.proxmox:
+        api_token_id: "{{ proxmox_api_token_id }}"
+        api_token_secret: "{{ proxmox_api_token_secret }}"
+      when: "proxmox_is_token_setup"
+  module_defaults:
+    community.proxmox.proxmox:
+      node: "{{ proxmox_node }}"
+      api_host: "{{ proxmox_api_host }}"
+      api_user: "{{ proxmox_api_user }}"
+      vmid: "{{ lxc_vmid }}"
+      state: started

--- a/roles/create-lxc/tasks/delete.yml
+++ b/roles/create-lxc/tasks/delete.yml
@@ -2,14 +2,27 @@
 - name: Get status of LXC.
   block:
     - name: "Get status of LXC '{{ lxc_vmid }}'."
-      community.proxmox.proxmox_vm_info:
-        node: "{{ proxmox_node }}"
-        api_host: "{{ proxmox_api_host }}"
-        api_user: "{{ proxmox_api_user }}"
-        api_password: "{{ proxmox_api_password }}"
-        vmid: "{{ lxc_vmid }}"
-      register: _proxmox_lxc_status
-      changed_when: false
+      block:
+        - name: "Get status of LXC '{{ lxc_vmid }}' via password."
+          community.proxmox.proxmox_vm_info:
+            api_password: "{{ proxmox_api_password }}"
+          register: _proxmox_lxc_status
+          changed_when: false
+          when: "proxmox_is_password_setup"
+
+        - name: "Get status of LXC '{{ lxc_vmid }}' via token."
+          community.proxmox.proxmox_vm_info:
+            api_token_id: "{{ proxmox_api_token_id }}"
+            api_token_secret: "{{ proxmox_api_token_secret }}"
+          register: _proxmox_lxc_status
+          changed_when: false
+          when: "proxmox_is_token_setup"
+      module_defaults:
+        community.proxmox.proxmox_vm_info:
+          node: "{{ proxmox_node }}"
+          api_host: "{{ proxmox_api_host }}"
+          api_user: "{{ proxmox_api_user }}"
+          vmid: "{{ lxc_vmid }}"
 
     - name: "Set fact if LXC '{{ lxc_vmid }}' exists."
       ansible.builtin.set_fact:
@@ -21,11 +34,22 @@
       when: lxc_exists
 
 - name: "Ensure LXC '{{ lxc_hostname }}' ({{ lxc_vmid }}) is stopped."
+  block:
+    - name: "Ensure LXC '{{ lxc_hostname }}' ({{ lxc_vmid }}) is stopped via password."
+      community.proxmox.proxmox:
+        api_password: "{{ proxmox_api_password }}"
+      when: "proxmox_is_password_setup"
+
+    - name: "Ensure LXC '{{ lxc_hostname }}' ({{ lxc_vmid }}) is stopped via token."
+      community.proxmox.proxmox:
+        api_token_id: "{{ proxmox_api_token_id }}"
+        api_token_secret: "{{ proxmox_api_token_secret }}"
+      when: "proxmox_is_token_setup"
+  module_defaults:
   community.proxmox.proxmox:
     node: "{{ proxmox_node }}"
     api_host: "{{ proxmox_api_host }}"
     api_user: "{{ proxmox_api_user }}"
-    api_password: "{{ proxmox_api_password }}"
     vmid: "{{ lxc_vmid }}"
     state: stopped
   when:
@@ -33,11 +57,22 @@
     - lxc_is_running
 
 - name: "Ensure LXC '{{ lxc_hostname }}' ({{ lxc_vmid }}) is deleted."
+  block:
+    - name: "Ensure LXC '{{ lxc_hostname }}' ({{ lxc_vmid }}) is deleted via password."
+      community.proxmox.proxmox:
+        api_password: "{{ proxmox_api_password }}"
+      when: "proxmox_is_password_setup"
+
+    - name: "Ensure LXC '{{ lxc_hostname }}' ({{ lxc_vmid }}) is deleted via token."
+      community.proxmox.proxmox:
+        api_token_id: "{{ proxmox_api_token_id }}"
+        api_token_secret: "{{ proxmox_api_token_secret }}"
+      when: "proxmox_is_token_setup"
+  module_defaults:
   community.proxmox.proxmox:
     node: "{{ proxmox_node }}"
     api_host: "{{ proxmox_api_host }}"
     api_user: "{{ proxmox_api_user }}"
-    api_password: "{{ proxmox_api_password }}"
     vmid: "{{ lxc_vmid }}"
     state: absent
   when: lxc_exists

--- a/roles/create-lxc/tasks/preflight.yml
+++ b/roles/create-lxc/tasks/preflight.yml
@@ -10,11 +10,24 @@
     - proxmox_node
     - proxmox_api_host
     - proxmox_api_user
-    - proxmox_api_password
     - lxc_vmid
     - lxc_hostname
     - lxc_password
     - lxc_appname
+
+- name: Check for password or token authentication.
+  block:
+    - name: Register password setup.
+      ansible.builtin.set_fact:
+        proxmox_is_password_setup: "{{ proxmox_api_password is defined and proxmox_api_password is string and proxmox_api_password | length > 0 }}"
+    - name: Register token setup.
+      ansible.builtin.set_fact:
+        proxmox_is_token_setup: "{{ proxmox_api_token_id is defined and proxmox_api_token_id is string and proxmox_api_token_id | length > 0 and proxmox_api_token_secret is defined and proxmox_api_token_secret is string and proxmox_api_token_secret | length > 0 }}"
+    - name: Check conflict between password and token setup.
+      ansible.builtin.assert:
+        that: "(not proxmox_is_password_setup and proxmox_is_token_setup) or (proxmox_is_password_setup and not proxmox_is_token_setup)"
+        fail_msg: "proxmox_api_password or proxmox_api_token_id and proxmox_api_token_secret must be defined, but not both."
+        quiet: true
 
 - name: Ensure pip is present.
   ansible.builtin.package:

--- a/roles/create-lxc/tasks/template.yml
+++ b/roles/create-lxc/tasks/template.yml
@@ -1,12 +1,23 @@
 ---
 - name: "Ensure template '{{ lxc_template }}' is present."
-  community.proxmox.proxmox_template:
-    node: "{{ proxmox_node }}"
-    api_host: "{{ proxmox_api_host }}"
-    api_user: "{{ proxmox_api_user }}"
-    api_password: "{{ proxmox_api_password }}"
-    storage: "{{ lxc_template_storage }}"
-    content_type: "{{ lxc_template_content_type }}"
-    template: "{{ lxc_template }}"
-    timeout: "{{ lxc_template_timeout }}"
-    state: present
+  block:
+    - name: "Ensure template '{{ lxc_template }}' is present via password."
+      community.proxmox.proxmox_template:
+        api_password: "{{ proxmox_api_password }}"
+      when: "proxmox_is_password_setup"
+
+    - name: "Ensure template '{{ lxc_template }}' is present via token."
+      community.proxmox.proxmox_template:
+        api_token_id: "{{ proxmox_api_token_id }}"
+        api_token_secret: "{{ proxmox_api_token_secret }}"
+      when: "proxmox_is_token_setup"
+  module_defaults:
+    community.proxmox.proxmox_template:
+      node: "{{ proxmox_node }}"
+      api_host: "{{ proxmox_api_host }}"
+      api_user: "{{ proxmox_api_user }}"
+      storage: "{{ lxc_template_storage }}"
+      content_type: "{{ lxc_template_content_type }}"
+      template: "{{ lxc_template }}"
+      timeout: "{{ lxc_template_timeout }}"
+      state: present


### PR DESCRIPTION
This PR adds the ability to control the create-lxc role using either the host password or a Proxmox API token.