### PR TITLE
role/create-lxc: Fix bug obtaining LXC status.

### DIFF
--- a/roles/create-lxc/tasks/create.yml
+++ b/roles/create-lxc/tasks/create.yml
@@ -88,32 +88,12 @@
 - name: Ensure LXC exists after its creation.
   block:
     - name: "Get status of LXC '{{ lxc_vmid }}'."
-      block:
-        - name: "Get status of LXC '{{ lxc_vmid }}' via password."
-          community.proxmox.proxmox_vm_info:
-            api_password: "{{ proxmox_api_password }}"
-          register: _proxmox_lxc_status
-          changed_when: false
-          when: "proxmox_is_password_setup"
-
-        - name: "Get status of LXC '{{ lxc_vmid }}' via token."
-          community.proxmox.proxmox_vm_info:
-            api_token_id: "{{ proxmox_api_token_id }}"
-            api_token_secret: "{{ proxmox_api_token_secret }}"
-          register: _proxmox_lxc_status
-          changed_when: false
-          when: "proxmox_is_token_setup"
-      module_defaults:
-        community.proxmox.proxmox_vm_info:
-          node: "{{ proxmox_node }}"
-          api_host: "{{ proxmox_api_host }}"
-          api_user: "{{ proxmox_api_user }}"
-          vmid: "{{ lxc_vmid }}"
+      ansible.builtin.import_tasks: get_lxc_status.yml
 
     - name: "Fail if the LXC does not exists after its creation."
       ansible.builtin.fail:
         msg: "LXC {{ lxc_vmid }} does not exists after its creation."
-      when: "_proxmox_lxc_status.proxmox_vms | length == 0 | bool"
+      when: "not lxc_status.exists"
 
 - name: "Ensure LXC '{{ lxc_hostname }}' ({{ lxc_vmid }}) is running."
   block:

--- a/roles/create-lxc/tasks/delete.yml
+++ b/roles/create-lxc/tasks/delete.yml
@@ -1,37 +1,6 @@
 ---
-- name: Get status of LXC.
-  block:
-    - name: "Get status of LXC '{{ lxc_vmid }}'."
-      block:
-        - name: "Get status of LXC '{{ lxc_vmid }}' via password."
-          community.proxmox.proxmox_vm_info:
-            api_password: "{{ proxmox_api_password }}"
-          register: _proxmox_lxc_status
-          changed_when: false
-          when: "proxmox_is_password_setup"
-
-        - name: "Get status of LXC '{{ lxc_vmid }}' via token."
-          community.proxmox.proxmox_vm_info:
-            api_token_id: "{{ proxmox_api_token_id }}"
-            api_token_secret: "{{ proxmox_api_token_secret }}"
-          register: _proxmox_lxc_status
-          changed_when: false
-          when: "proxmox_is_token_setup"
-      module_defaults:
-        community.proxmox.proxmox_vm_info:
-          node: "{{ proxmox_node }}"
-          api_host: "{{ proxmox_api_host }}"
-          api_user: "{{ proxmox_api_user }}"
-          vmid: "{{ lxc_vmid }}"
-
-    - name: "Set fact if LXC '{{ lxc_vmid }}' exists."
-      ansible.builtin.set_fact:
-        lxc_exists: "{{ _proxmox_lxc_status.proxmox_vms | length > 0 | bool }}"
-
-    - name: "Set fact if LXC '{{ lxc_vmid }}' is running."
-      ansible.builtin.set_fact:
-        lxc_is_running: "{{ _proxmox_lxc_status.proxmox_vms[0].status == 'running' }}"
-      when: lxc_exists
+- name: "Get status of LXC '{{ lxc_vmid }}'."
+  ansible.builtin.import_tasks: get_lxc_status.yml
 
 - name: "Ensure LXC '{{ lxc_hostname }}' ({{ lxc_vmid }}) is stopped."
   block:
@@ -46,15 +15,15 @@
         api_token_secret: "{{ proxmox_api_token_secret }}"
       when: "proxmox_is_token_setup"
   module_defaults:
-  community.proxmox.proxmox:
-    node: "{{ proxmox_node }}"
-    api_host: "{{ proxmox_api_host }}"
-    api_user: "{{ proxmox_api_user }}"
-    vmid: "{{ lxc_vmid }}"
-    state: stopped
+    community.proxmox.proxmox:
+      node: "{{ proxmox_node }}"
+      api_host: "{{ proxmox_api_host }}"
+      api_user: "{{ proxmox_api_user }}"
+      vmid: "{{ lxc_vmid }}"
+      state: stopped
   when:
-    - lxc_exists
-    - lxc_is_running
+    - lxc_status.exists
+    - lxc_status.status == "running"
 
 - name: "Ensure LXC '{{ lxc_hostname }}' ({{ lxc_vmid }}) is deleted."
   block:
@@ -69,10 +38,10 @@
         api_token_secret: "{{ proxmox_api_token_secret }}"
       when: "proxmox_is_token_setup"
   module_defaults:
-  community.proxmox.proxmox:
-    node: "{{ proxmox_node }}"
-    api_host: "{{ proxmox_api_host }}"
-    api_user: "{{ proxmox_api_user }}"
-    vmid: "{{ lxc_vmid }}"
-    state: absent
-  when: lxc_exists
+    community.proxmox.proxmox:
+      node: "{{ proxmox_node }}"
+      api_host: "{{ proxmox_api_host }}"
+      api_user: "{{ proxmox_api_user }}"
+      vmid: "{{ lxc_vmid }}"
+      state: absent
+  when: lxc_status.exists

--- a/roles/create-lxc/tasks/get_lxc_status.yml
+++ b/roles/create-lxc/tasks/get_lxc_status.yml
@@ -1,0 +1,42 @@
+---
+# This task checks the status of a given LXC and sets
+# the variable lxc_status with the result.
+# The result variable contains a dictionary with the following fields:
+# - lxc_status:
+#   exists: If the LXC is present.
+#   status: String with the statis of the LXC; empty if it doesn't exist.
+- name: "Get status of LXC '{{ lxc_vmid }}'."
+  block:
+    - name: "Get status of LXC '{{ lxc_vmid }}' via password."
+      community.proxmox.proxmox_vm_info:
+        api_password: "{{ proxmox_api_password }}"
+      register: _proxmox_lxc_status_pwd
+      when: "proxmox_is_password_setup"
+
+    - name: "Get status of LXC '{{ lxc_vmid }}' via token."
+      community.proxmox.proxmox_vm_info:
+        api_token_id: "{{ proxmox_api_token_id }}"
+        api_token_secret: "{{ proxmox_api_token_secret }}"
+      register: _proxmox_lxc_status_token
+      when: "proxmox_is_token_setup"
+  module_defaults:
+    community.proxmox.proxmox_vm_info:
+      node: "{{ proxmox_node }}"
+      api_host: "{{ proxmox_api_host }}"
+      api_user: "{{ proxmox_api_user }}"
+      vmid: "{{ lxc_vmid }}"
+
+- name: Set '_proxmox_vm_info_result' variable from retrieved state.
+  ansible.builtin.set_fact:
+    _proxmox_vm_info_result: "{{ (not (_proxmox_lxc_status_token.skipped | default(false))) | ternary(_proxmox_lxc_status_token, _proxmox_lxc_status_pwd) }}"
+
+- name: Fail if the status is not defined.
+  ansible.builtin.fail:
+    msg: "Error retrieving status of LXC '{{ lxc_vmid }}'."
+  when: "_proxmox_vm_info_result.proxmox_vms is not defined"
+
+- name: Set 'lxc_status' variable with the state.
+  set_fact:
+    lxc_status:
+      exists: "{{ _proxmox_vm_info_result.proxmox_vms | length > 0 | bool }}"
+      status: "{{ _proxmox_vm_info_result.proxmox_vms[0].status if _proxmox_vm_info_result.proxmox_vms | length > 0 else '' }}"

--- a/roles/create-lxc/tasks/main.yml
+++ b/roles/create-lxc/tasks/main.yml
@@ -1,17 +1,17 @@
 #SPDX-License-Identifier: MIT-0
 ---
 # tasks file for create-lxc
-- name: Include preflight task.
-  ansible.builtin.include_tasks: preflight.yml
+- name: Run preflight checks.
+  ansible.builtin.import_tasks: preflight.yml
 
-- name: Include template task.
+- name: Ensure the template is present.
   ansible.builtin.include_tasks: template.yml
   when: not lxc_delete
 
-- name: Include create task.
+- name: Create the LXC.
   ansible.builtin.include_tasks: create.yml
   when: not lxc_delete
 
-- name: Include delete task.
+- name: Delete the LXC.
   ansible.builtin.include_tasks: delete.yml
   when: lxc_delete


### PR DESCRIPTION
This PR fixes a bug introduced by the recent feature that allows making API calls both with password and token authentication. 
This feature involves using two tasks, both with a when condition and some common variables, to determine which authentication method to use for all Proxmox API calls.

The bug was present when retrieving the status of a running LXC. The code would register the same variable for both tasks. When running Ansible will register any variable even if the task was skipped. This means that in the case when we used password authentication (the password task is run before), the variable registered will be overridden by the skipped token task, resulting in an invalid status for the LXC.

To fix this bug, we split all the tasks needed to retrieve the status into a different file called `get_lxc_status.yml`. 
These tasks define a `lxc_staus` variable that can be used consistently in both create and delete flows.