### PR TITLE
role/create-lxc: Ensure bind mount exists on host

### DIFF
--- a/roles/create-lxc/tasks/create.yml
+++ b/roles/create-lxc/tasks/create.yml
@@ -1,8 +1,10 @@
 ---
 - name: Ensure bind mount folders exist on the host.
   ansible.builtin.file:
-    # TODO: Determine the correct owner/group for the mounts
     path: "{{ item.bind }}"
+    owner: "root"
+    group: "root"
+    mode: "0755"
     state: directory
   loop: "{{ lxc_mounts }}"
   loop_control:


### PR DESCRIPTION
This PR adds a task to the `create-lxc` role that ensures that any bind mount directory exists on the Proxmox host.