### PR TITLE
Better document available variables inside roles.

### DIFF
--- a/roles/create-lxc/README.md
+++ b/roles/create-lxc/README.md
@@ -11,97 +11,40 @@ None.
 Role Variables
 --------------
 
-Available variables are listed below, along with default values (see 'defaults/main.yml'):
+Available variables are listed below, along with default values (see 'defaults/main.yml' for a complete list):
 
-Main LXC settings.
-
-```yaml
-lxc_vmid: <id>            # (Required)
-lxc_hostname: <hostname>  # (Required)
-lxc_password: <pwd>       # (Required)
-lxc_appname: lxc_hostname # Human-Readable app name.
-```
-
-Template image for the container and where it is stored.
-
-> Check the [official Proxmox repository](http://download.proxmox.com/images/system/) for the available images.
-
-```yaml
-lxc_template: "debian-12-standard_12.7-1_amd64.tar.zst"
-lxc_template_storage: "local"
-```
-
-LXC Hardwere specs.
-
-```yaml
-lxc_unprivileged: true
-lxc_cores: 1
-lxc_memory: 1024
-lxc_swap: 512
-lxc_features: "keyctl=1,nesting=1"
-```
-
-Main Disk specs.
-
-```yaml
-lxc_disk_storage: "local-lvm"
-lxc_disk_size: 4  # in GB
-```
-
-Additional Mount points.
-
-> Note: At the moment it is only possible to define **bind mounts** to some folder in the host device.
-
-```yaml
-lxc_mounts: []
-# - id: mp0
-#   bind: /mnt/binds
-#   mount: /shared
-```
-
-Network specs.
-
-```yaml
-lxc_network: []
-# - id: net0
-#   name: eth0
-#   ip4: 192.168.1.10 # Optional. Available options: valid IPv4 address (to use static) - dhcp (to use DHCP).
-#   netmask4: 24      # Optional if IPv4 not indicated.
-#   gw4: 192.168.1.1  # Optional.
-#   ip6: 200:db8::10  # Optional. Available options: valid IPv6 address (to use static) - dhcp (to use DHCP) - auto (to use SLAAC).
-#   netmask6: 64      # Optional if IPv6 not indicated.
-#   gw6: 200:db8::1   # Optional.
-#   bridge: vmbr0     # Default 'vmbr0'.
-#   firewall: false   # Optional.
-#   vlan_tag: 200     # Optional.
-```
-
-Startup options.
-
-```yaml
-lxc_onboot: false
-lxc_startup: ""
-```
-
-Extra options
-
-```yaml
-lxc_nameserver: "" # DNS nameserver.
-lxc_pubkey: "" # Path to an SSH key to use for secure connection.
-lxc_tags:
-  - "ansible"
-```
-
-This role also **requires** the following variables to be defined:
-
-```yaml
-proxmox_node: <node_name>           # (Required)
-proxmox_api_host: <node_ip>         # (Required)
-proxmox_api_user: <node_user@realm> # (Required)
-proxmox_api_password: <pwd>         # (Required)
-proxmox_api_token_id: <id>          # (Required)
-proxmox_api_token_secret: <secret>  # (Required)
-```
+| Name | Required | Type | Default | Description |
+| - | - | - | - | - |
+| `proxmox_node` | Yes | string | | Proxmox host node. |
+| `proxmox_api_host` | Yes | string | | Address of the Proxmox API host. |
+| `proxmox_api_user` | Yes | string | | Proxmox API user. |
+| `proxmox_api_password` | Yes | string | | Password for Proxmox API. <br/>This option is mutually exclusive with `proxmox_api_token_id` and `proxmox_api_token_secret`. |
+| `proxmox_api_token_id` | Yes | string | | Token ID for Proxmox API. <br/>This option is mutually exclusive with `proxmox_api_password`. |
+| `proxmox_api_token_secret` | Yes | string | | Token secret for Proxmox API. <br/>This option is mutually exclusive with `proxmox_api_password`. |
+| `lxc_vmid` | Yes | int | | LXC ID. |
+| `lxc_hostname` | Yes | string | | LXC hostname. |
+| `lxc_password` | Yes | string | | LXC password. |
+| `lxc_appname` | | string |  `"{{ lxc_hostname }}"` | Human-readable app name.|
+| `lxc_delete` | | bool | `false` | Delete the LXC insted of creating it. |
+| `lxc_template` | | string | `"debian-12-standard_12.7-1_amd64.tar.zst"` | Name of Template image to download. <br/> Check the [official Proxmox repository](http://download.proxmox.com/images/system/) for the available images. |
+| `lxc_template_storage` | | string | `"local"` | Storage where the Template is downloaded.|
+| `lxc_template_content_type` | | string | `"vztmpl"` | Template contenty type. |
+| `lxc_template_timeout` | | int | `180` | Timeout when downloading LXC template image. <br/>Increese this value based on your internet connection speed. |
+| `lxc_unprivileged` | | bool | `true` | Create an unprivileged LXC. If `false` a privileged LXC will be created instead. |
+| `lxc_cores` | | `1` | int | Number of cores for the LXC CPU. |
+| `lxc_memory` | | `1024` | int | Amount of RAM in MB for the LXC. |
+| `lxc_swap` | | `512` | int | Size of the swap in MB for the LCX. |
+| `lxc_disk_storage` | | string | `"local-lvm"` | Storage for the LXC main disk. |
+| `lxc_disk_size` | | int | `4` | Size in GB of the LXC main disk. |
+| `lxc_mounts` | | list | `[]` | Additional mount points for the LXC. <br/>Note: At the moment it is only possible to define **bind mounts** to some folder in the Proxmox host. |
+| `lxc_network` | | list | `[]` | LXC network interfaces. |
+| `lxc_onboot` | | bool | `false` | Start the LXC at host's bootup. |
+| `lxc_startup` | | string | `""` | LXC startup options. |
+| `lxc_nameserver` | | string | `""` | DNS nameserver. |
+| 'lxc_timezone` | | string | `"host"` | LXC Timezone. |
+| `lxc_pubkey` | | string | `""` | Path to an SSH key to use for secure connection to the LXC. |
+| `lxc_features` | | string | `"keyctl=1,nesting=1"` | Additional LXC features. |
+| `lxc_tags` | | list | `["ansible"]` | LXC Tags. |
 
 Dependencies
 ------------


### PR DESCRIPTION
This PR changes the way role variables are documented inside roles' `README.md` files.

Previously, all the variables available to a role were listed in plain text, along with some examples in YAML code blocks. This would cause issues when searching for a specific variable or looking for all the possible values.

Now we use a simple markdown table that describes all the variables a role can have, along with their default value and if they are required or not.

This new method will improve clarity and consistency across all roles.