### PR TITLE
Add `system-locale` Role

### DIFF
--- a/roles/system-locale/README.md
+++ b/roles/system-locale/README.md
@@ -1,0 +1,44 @@
+Ansible Role: system-locale
+=========
+
+An Ansible Role that sets system locale and timezone on Linux.
+
+Requirements
+------------
+
+None.
+
+Role Variables
+--------------
+
+Available variables are listed below, along with default values (see 'defaults/main.yml' for a complete list):
+
+| Name | Required | Type | Default | Description |
+| - | - | - | - | - |
+|`system_locale_lang` | | string | `"en_US.UTF-8"` | Locale string. |
+|`system_locale_timezone` | | string | `"UTC"` | Timezone string. |
+
+Dependencies
+------------
+
+None.
+
+Example Playbook
+----------------
+
+```yaml
+- name: Setup locale
+  hosts: all
+  roles:
+    - role: system-locale
+```
+
+License
+-------
+
+MIT
+
+Author Information
+------------------
+
+This role was created in 2025 by Lorenzo Calsti.

--- a/roles/system-locale/defaults/main.yml
+++ b/roles/system-locale/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+system_locale_lang: "en_US.UTF-8"
+system_locale_timezone: "UTC"

--- a/roles/system-locale/handlers/main.yml
+++ b/roles/system-locale/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# Empty file

--- a/roles/system-locale/meta/main.yml
+++ b/roles/system-locale/meta/main.yml
@@ -1,0 +1,30 @@
+---
+dependencies: []
+
+galaxy_info:
+  role_name: system_locale
+  author: Lorenzo Calisti
+  description: Set locale on Linux.
+  license: MIT
+  min_ansible_version: "2.1"
+  platforms:
+    - name: ArchLinux
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - bullseye
+        - bookworm
+    - name: EL
+      versions:
+        - all
+    - name: Fedora
+      versions:
+        - all
+    - name: Ubuntu
+      versions:
+        - focal
+        - jammy
+        - noble
+  galaxy_tags:
+    - locale

--- a/roles/system-locale/tasks/main.yml
+++ b/roles/system-locale/tasks/main.yml
@@ -1,0 +1,42 @@
+---
+- name: Load OS-specific vars.
+  ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
+  vars:
+    params:
+      files:
+        - "{{ ansible_distribution }}.yml"
+        - "{{ ansible_os_family }}.yml"
+        - main.yml
+      paths:
+        - "vars"
+
+- name: Ensure locale packages are present.
+  ansible.builtin.package:
+    name: "{{ system_locale_packages }}"
+    state: present
+
+- name: Generate locale.
+  when: ansible_os_family == 'Debian'
+  community.general.locale_gen:
+    name: "{{ system_locale_lang }}"
+
+- name: Get current locale.
+  block:
+    - name: Query current locale.
+      ansible.builtin.command: "localectl status"
+      register: _system_locale_status
+      changed_when: false
+
+    - name: Set '_current_locale_lang' with current locale.
+      ansible.builtin.set_fact:
+        _current_locale_lang: "{{ _system_locale_status.stdout | regex_search('LANG=([^\n]+)', '\\1') | first }}"
+
+- name: Set locale.
+  ansible.builtin.command: >-
+    localectl set-locale {{ system_locale_lang }}
+  when: system_locale_lang != _current_locale_lang
+  changed_when: true
+
+- name: Set timezone.
+  community.general.timezone:
+    name: "{{ system_locale_timezone }}"

--- a/roles/system-locale/tests/inventory
+++ b/roles/system-locale/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/roles/system-locale/tests/test.yml
+++ b/roles/system-locale/tests/test.yml
@@ -1,0 +1,6 @@
+---
+- name: Test system-locale Role.
+  hosts: localhost
+  remote_user: root
+  roles:
+    - system-locale

--- a/roles/system-locale/vars/Debian.yml
+++ b/roles/system-locale/vars/Debian.yml
@@ -1,0 +1,4 @@
+---
+system_locale_packages:
+  - locales
+  - tzdata

--- a/roles/system-locale/vars/RedHat.yml
+++ b/roles/system-locale/vars/RedHat.yml
@@ -1,0 +1,4 @@
+---
+system_locale_packages:
+  - "glibc-langpack-{{ system_locale_lang.split('_')[0] | lower }}"
+  - "tzdata"

--- a/roles/system-locale/vars/main.yml
+++ b/roles/system-locale/vars/main.yml
@@ -1,0 +1,2 @@
+---
+system_locale_packages: []


### PR DESCRIPTION
This PR adds the `system-locale` Ansible Role to configure the system locale and timezone on Linux.