### PR TITLE
Add `motd` Role

### DIFF
--- a/roles/motd/README.md
+++ b/roles/motd/README.md
@@ -1,0 +1,64 @@
+Ansible Role: motd
+=========
+
+Set a static Message of the Day (MOTD) on Linux.
+
+Requirements
+------------
+
+None.
+
+Role Variables
+--------------
+
+Available variables are listed below, along with default values (see 'defaults/main.yml' for a complete list):
+
+| Name | Required | Type | Default | Description |
+| - | - | - | - | - |
+| `motd_content` | | string | | Full message printed my the MOTD. |
+
+Dependencies
+------------
+
+None.
+
+Example Playbook
+----------------
+
+```yaml
+- name: MOTD
+  hosts: all
+  roles:
+    - role: motd
+```
+
+This Playbook produce a `/etc/motd` file like this:
+
+```
+--------------------------------------------------------------------------
+                    This system is managed by Ansible
+--------------------------------------------------------------------------
+
+NOTE: System and application configuration for this host is managed by
+automated systems. To ensure that any changes you make here are not lost,
+please contact your system administrators.
+
+FQDN:     fedora.example.com
+Distro:   Fedora 33
+Virtual:  YES (lxc)
+CPUs:     2
+RAM:      0.5 GB
+Timezone: CET(+0100)
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+```
+
+License
+-------
+
+MIT
+
+Author Information
+------------------
+
+This role was created in 2025 by Lorenzo Calsti.

--- a/roles/motd/defaults/main.yml
+++ b/roles/motd/defaults/main.yml
@@ -1,0 +1,19 @@
+---
+motd_content: |
+
+  --------------------------------------------------------------------------
+                      This system is managed by Ansible
+  --------------------------------------------------------------------------
+
+  NOTE: System and application configuration for this host is managed by
+  automated systems. To ensure that any changes you make here are not lost,
+  please contact your system administrators.
+
+  FQDN:     {{ ansible_fqdn }}
+  Distro:   {{ ansible_distribution }} {{ ansible_distribution_version }} {{ ansible_distribution_release }}
+  Virtual:  {{ 'YES (' ~ ansible_virtualization_type ~ ')' if ansible_virtualization_role == 'guest' else 'NO' }}
+  CPUs:     {{ ansible_processor_vcpus }}
+  RAM:      {{ (ansible_memtotal_mb / 1000) | round(1) }} GB
+  Timezone: {{ ansible_date_time.tz }}({{ ansible_date_time.tz_offset }})
+
+  - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/roles/motd/handlers/main.yml
+++ b/roles/motd/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# Empty file

--- a/roles/motd/meta/main.yml
+++ b/roles/motd/meta/main.yml
@@ -1,0 +1,32 @@
+dependencies: []
+
+galaxy_info:
+  role_name: motd
+  author: Lorenzo Calisti
+  description: Set Message of the Day (MOTD) on Linux.
+  license: MIT
+  min_ansible_version: "2.1"
+  platforms:
+    - name: ArchLinux
+      versions:
+        - all
+    - name: Alpine
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - bullseye
+        - bookworm
+    - name: EL
+      versions:
+        - all
+    - name: Fedora
+      versions:
+        - all
+    - name: Ubuntu
+      versions:
+        - focal
+        - jammy
+        - noble
+  galaxy_tags:
+    - motd

--- a/roles/motd/tasks/main.yml
+++ b/roles/motd/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+- name: Load OS-specific vars.
+  ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
+  vars:
+    params:
+      files:
+        - "{{ ansible_distribution }}.yml"
+        - "{{ ansible_os_family }}.yml"
+        - main.yml
+      paths:
+        - "vars"
+
+- name: Remove dynamic MOTD.
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  loop: "{{ motd_remove_dynamic }}"
+
+- name: Configure static MOTD file.
+  ansible.builtin.copy:
+    dest: "/etc/motd"
+    content: "{{ motd_content }}"
+    owner: "root"
+    group: "root"
+    mode: "0755"

--- a/roles/motd/tests/inventory
+++ b/roles/motd/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/roles/motd/tests/test.yml
+++ b/roles/motd/tests/test.yml
@@ -1,0 +1,6 @@
+---
+- name: Test motd Role.
+  hosts: localhost
+  remote_user: root
+  roles:
+    - motd

--- a/roles/motd/vars/Debian.yml
+++ b/roles/motd/vars/Debian.yml
@@ -1,0 +1,3 @@
+---
+motd_remove_dynamic:
+  - "/etc/update-motd.d/10-uname"

--- a/roles/motd/vars/Ubuntu.yml
+++ b/roles/motd/vars/Ubuntu.yml
@@ -1,0 +1,8 @@
+---
+motd_remove_dynamic:
+  - "/etc/update-motd.d/00-header"
+  - "/etc/update-motd.d/10-help-text"
+  - "/etc/update-motd.d/50-motd-news"
+  - "/etc/update-motd.d/88-esm-announce"
+  - "/etc/update-motd.d/91-contract-ua-esm-status"
+  - "/etc/update-motd.d/91-release-upgrade"

--- a/roles/motd/vars/main.yml
+++ b/roles/motd/vars/main.yml
@@ -1,0 +1,2 @@
+---
+motd_remove_dynamic: []


### PR DESCRIPTION
This PR adds the `motd` Ansible Role that sets the Message of the Day (MOTD) on Linux.

This role takes inspiration from other roles like:

- https://github.com/adriagalin/ansible.motd/tree/master
- https://github.com/manala/ansible-roles/tree/main/roles/motd
- https://github.com/arillso/ansible.motd/tree/master