### PR TITLE
Add `ssh` role

### DIFF
--- a/roles/ssh/README.md
+++ b/roles/ssh/README.md
@@ -1,0 +1,55 @@
+Ansible Role: ssh
+=========
+
+Configure a secure SSH server on Linux.
+
+This role performs some basic security configurations for SSH on any popular Linux distribution.
+
+Requirements
+------------
+
+None.
+
+Role Variables
+--------------
+
+
+Available variables are listed below, along with default values (see 'defaults/main.yml' for a complete list):
+
+| Name | Required | Type | Default | Description |
+| - | - | - | - | - |
+|`ssh_port`| | int | `22` | Port number that sshd listens on. |
+|`ssh_password_authentication`| | string | `"no"` | Specifies whether password authentication is allowed.|
+|`ssh_permit_root_login`| | string | `"no"` | Specifies whether root can log in using ssh.|
+|`ssh_usedns`| | string | `"no"` | Specifies whether sshd should look up the remote host name.|
+|`ssh_permit_empty_password`| | string | `"no"` | When password authentication is allowed, allows accounts with empty passwords.|
+|`ssh_challenge_response_auth`| | string | `"no"` | Enables PAM authentication.|
+|`ssh_gss_api_authentication`| | string | `"no"` | Specifies whether user authentication based on GSSAPI is allowed.|
+|`ssh_x11_forwarding`| | string | `"no"` | Specifies whether X11 forwarding is permitted.|
+|`ssh_allowed_users`| | list | `[]` | List of user names that can exclusively log in using ssh. |
+|`ssh_allowed_groups`| | list | `[]` | List of group names that can exclusively log in using ssh.|
+
+Dependencies
+------------
+
+None.
+
+Example Playbook
+----------------
+
+```yaml
+- name: SSH
+  hosts: all
+  roles:
+    - role: ssh
+```
+
+License
+-------
+
+MIT
+
+Author Information
+------------------
+
+This role was created in 2025 by Lorenzo Calsti.

--- a/roles/ssh/defaults/main.yml
+++ b/roles/ssh/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+ssh_port: 22
+ssh_password_authentication: "no"
+ssh_permit_root_login: "no"
+ssh_usedns: "no"
+ssh_permit_empty_password: "no"
+ssh_challenge_response_auth: "no"
+ssh_gss_api_authentication: "no"
+ssh_x11_forwarding: "no"
+ssh_allowed_users: []
+ssh_allowed_groups: []

--- a/roles/ssh/handlers/main.yml
+++ b/roles/ssh/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+- name: reload systemd # noqa: name[casing]
+  ansible.builtin.systemd_service:
+    daemon_reload: true
+  when: ansible_facts.service_mgr == "systemd"
+
+- name: restart ssh # noqa: name[casing]
+  ansible.builtin.service:
+    name: "{{ ssh_sshd_name }}"
+    state: "restarted"

--- a/roles/ssh/meta/main.yml
+++ b/roles/ssh/meta/main.yml
@@ -1,0 +1,34 @@
+---
+dependencies: []
+
+galaxy_info:
+  role_name: ssh
+  author: Lorenzo Calisti
+  description: Configure SSH on Linux.
+  license: MIT
+  min_ansible_version: "2.1"
+  platforms:
+    - name: ArchLinux
+      versions:
+        - all
+    - name: Alpine
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - bullseye
+        - bookworm
+    - name: EL
+      versions:
+        - all
+    - name: Fedora
+      versions:
+        - all
+    - name: Ubuntu
+      versions:
+        - focal
+        - jammy
+        - noble
+  galaxy_tags:
+    - ssh
+    - security

--- a/roles/ssh/tasks/main.yml
+++ b/roles/ssh/tasks/main.yml
@@ -1,0 +1,70 @@
+---
+# Inspired by https://github.com/geerlingguy/ansible-role-security/blob/master/tasks/ssh.yml
+- name: Load OS-specific vars.
+  ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
+  vars:
+    params:
+      files:
+        - "{{ ansible_distribution }}.yml"
+        - "{{ ansible_os_family }}.yml"
+        - main.yml
+      paths:
+        - "vars"
+
+- name: Ensure SSH daemon is running.
+  ansible.builtin.service:
+    name: "{{ ssh_sshd_name }}"
+    state: "started"
+
+- name: Update SSH configuration to be more secure.
+  ansible.builtin.lineinfile:
+    dest: "{{ ssh_config_path }}"
+    regexp: "{{ item.regexp }}"
+    line: "{{ item.line }}"
+    state: present
+    validate: "sshd -T -f %s"
+    mode: "0644"
+  with_items:
+    - regexp: "^PasswordAuthentication"
+      line: "PasswordAuthentication {{ ssh_password_authentication }}"
+    - regexp: "^PermitRootLogin"
+      line: "PermitRootLogin {{ ssh_permit_root_login }}"
+    - regexp: "^Port"
+      line: "Port {{ ssh_port }}"
+    - regexp: "^UseDNS"
+      line: "UseDNS {{ ssh_usedns }}"
+    - regexp: "^PermitEmptyPasswords"
+      line: "PermitEmptyPasswords {{ ssh_permit_empty_password }}"
+    - regexp: "^ChallengeResponseAuthentication"
+      line: "ChallengeResponseAuthentication {{ ssh_challenge_response_auth }}"
+    - regexp: "^GSSAPIAuthentication"
+      line: "GSSAPIAuthentication {{ ssh_gss_api_authentication }}"
+    - regexp: "^X11Forwarding"
+      line: "X11Forwarding {{ ssh_x11_forwarding }}"
+  notify:
+    - reload systemd
+    - restart ssh
+
+- name: Add configured users allowed to connect over ssh.
+  ansible.builtin.lineinfile:
+    dest: "{{ ssh_config_path }}"
+    regexp: "^AllowUsers"
+    line: "AllowUsers {{ ssh_allowed_users | join(' ') }}"
+    state: present
+    create: true
+    validate: "sshd -T -f %s"
+    mode: "0644"
+  when: ssh_allowed_users | length > 0
+  notify: restart ssh
+
+- name: Add configured groups allowed to connect over ssh.
+  ansible.builtin.lineinfile:
+    dest: "{{ ssh_config_path }}"
+    regexp: "^AllowGroups"
+    line: "AllowGroups {{ ssh_allowed_groups | join(' ') }}"
+    state: present
+    create: true
+    validate: "sshd -T -f %s"
+    mode: "0644"
+  when: ssh_allowed_groups | length > 0
+  notify: restart ssh

--- a/roles/ssh/tests/inventory
+++ b/roles/ssh/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/roles/ssh/tests/test.yml
+++ b/roles/ssh/tests/test.yml
@@ -1,0 +1,6 @@
+---
+- name: Test ssh Role.
+  hosts: localhost
+  remote_user: root
+  roles:
+    - ssh

--- a/roles/ssh/vars/Alpine.yml
+++ b/roles/ssh/vars/Alpine.yml
@@ -1,0 +1,3 @@
+---
+ssh_sshd_name: "sshd"
+ssh_config_path: "/etc/ssh/sshd_config"

--- a/roles/ssh/vars/Archlinux.yml
+++ b/roles/ssh/vars/Archlinux.yml
@@ -1,0 +1,3 @@
+---
+ssh_sshd_name: "sshd"
+ssh_config_path: "/etc/ssh/sshd_config"

--- a/roles/ssh/vars/Debian.yml
+++ b/roles/ssh/vars/Debian.yml
@@ -1,0 +1,3 @@
+---
+ssh_sshd_name: "ssh"
+ssh_config_path: "/etc/ssh/sshd_config"

--- a/roles/ssh/vars/RedHat.yml
+++ b/roles/ssh/vars/RedHat.yml
@@ -1,0 +1,3 @@
+---
+ssh_sshd_name: "sshd"
+ssh_config_path: "/etc/ssh/sshd_config"

--- a/roles/ssh/vars/main.yml
+++ b/roles/ssh/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# Empty file


### PR DESCRIPTION
This PR adds the `ssh` Ansible Role responsible for configuring and securing SSH servers on Linux.