### PR TITLE
Deprecated `ansible_managed` variable

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -3,4 +3,3 @@ nocows=True
 inventory=./inventory
 interpreter_python=auto_silent
 vault_password_file=.vault-password
-ansible_managed=WARNING: This file is managed by Ansible.

--- a/inventory/group_vars/all/ansible.yml
+++ b/inventory/group_vars/all/ansible.yml
@@ -1,0 +1,2 @@
+---
+ansible_managed: "WARNING: This file is managed by Ansible."


### PR DESCRIPTION
In this PR, we fix the deprecation warning for the `ansible_managed` variable. 

To set a custom Ansible-managed message, we needed to set its value in `ansible.cfg`; however, this use is now deprecated, and it can be used as a normal variable.