### PR TITLE
Fix validate command in `system-users` role

### DIFF
--- a/roles/system-users/tasks/main.yml
+++ b/roles/system-users/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-# Inspired by [this role](https://github.com/robertdebock/ansible-role-users/tree/master)
+# Inspired by https://github.com/robertdebock/ansible-role-users/tree/master
 - name: Ensure system packages are present.
   ansible.builtin.package:
     name: "{{ system_users_packages }}"
@@ -18,7 +18,7 @@
         path: /etc/sudoers
         line: "{{ system_users_sudo_includedir }}"
         regexp: "^(@|#)includedir"
-        validate: "/usr/bin/visudo -cf %s"
+        validate: "{{ system_users_sudo_validate_cmd }}"
 
 - name: Ensure groups exists.
   ansible.builtin.import_tasks: groups.yml


### PR DESCRIPTION
This PR fixes a bug caused by a typo in the hard-coded path to `visudo`. The paths are now replaced by an Ansible variable.