### PR TITLE
Set hookscript when creating LXCs

### DIFF
--- a/roles/create-lxc/README.md
+++ b/roles/create-lxc/README.md
@@ -1,7 +1,10 @@
 Ansible Role: create-lxc
 =========
 
-An Ansible Role that creates a Proxmox LXC.
+An Ansible Role that creates and configures LXC containers on Proxmox VE using the Proxmox API.
+
+The role is responsible only for container creation and base configuration.
+It assumes that Proxmox is already installed, reachable, and properly configured.
 
 Requirements
 ------------
@@ -11,33 +14,46 @@ None.
 Role Variables
 --------------
 
-Available variables are listed below, along with default values (see 'defaults/main.yml' for a complete list):
+Available variables are listed below, along with default values (see 'defaults/main.yml' for a complete list).
 
-### Proxmox API variables
+Variables are divided into two logical groups:
+
+1. Proxmox API connection
+2. LXC container definition
+
+### Proxmox API connection variables
+
+These variables define how Ansible authenticates and connects to the Proxmox API.
 
 | Name | Required | Type | Default | Description |
 | - | - | - | - | - |
 | `proxmox_node` | Yes | string | | Proxmox host node. |
 | `proxmox_api_host` | | string | `"localhost"` | Address of the Proxmox API host. |
 | `proxmox_api_user` | Yes | string | | Proxmox API user. |
-| `proxmox_api_password` | Yes | string | | Password for Proxmox API. <br/>This option is mutually exclusive with `proxmox_api_token_id` and `proxmox_api_token_secret`. |
-| `proxmox_api_token_id` | Yes | string | | Token ID for Proxmox API. <br/>This option is mutually exclusive with `proxmox_api_password`. |
-| `proxmox_api_token_secret` | Yes | string | | Token secret for Proxmox API. <br/>This option is mutually exclusive with `proxmox_api_password`. |
 
-### LXC guest variables
+For authentication you must use either password-based authentication or API tokens, not both.
 
-Variables related to the guest LXC are defined as fields of the `proxmox_lxc` dictionary:
+| Name | Required | Type | Description |
+| - | - | - | - |
+| `proxmox_api_password` | Yes | string | Password for API user. Mutually exclusive with token-based auth. |
+| `proxmox_api_token_id` | Yes | string | API token ID. Mutually exclusive with password auth. |
+| `proxmox_api_token_secret` | Yes | string | API token secret. Mutually exclusive with password auth. |
+
+### LXC container variables
+
+All container-related settings are defined inside the `proxmox_lxc` dictionary.
 
 | Name | Required | Type | Default | Description |
 | - | - | - | - | - |
-| `vmid` | Yes | int | | LXC container ID. |
+| `vmid` | Yes | int | | Unique LXC container ID. |
 | `hostname` | Yes | string | | Hostname of the container. |
-| `password` | Yes | string | | Password of the container. |
+| `password` | Yes | string | | Root password of the container. |
 | `unprivileged` | | bool | `true` | Create a privileged/unprivileged LXC. |
 | `template.name` | Yes | string | | Template image name. <br/> See the [official Proxmox repository](http://download.proxmox.com/images/system). |
 | `template.storage` | | string | `"local"` | Storage where the Template is downloaded.|
 | `template.content_type` | | string | `"vztmpl"` | Template content type. |
 | `template.timeout` | | int |  | Timeout for template download (in seconds). |
+| `hookscript` | | string | | Script that will be executed during various steps in the containers lifetime. |
 | `cpus` | | int | | Number of allocated cpus. |
 | `cores` | | int | | Number of cores per socket. |
 | `memory` | | int | | Amount of RAM in MB. |

--- a/roles/create-lxc/tasks/configure.yml
+++ b/roles/create-lxc/tasks/configure.yml
@@ -7,3 +7,7 @@
 
 - name: Set mount volumes.
   ansible.builtin.import_tasks: mount_volumes.yml
+
+- name: Set hookscript.
+  ansible.builtin.include_tasks: hookscript.yml
+  when: proxmox_lxc.hookscript is defined

--- a/roles/create-lxc/tasks/hookscript.yml
+++ b/roles/create-lxc/tasks/hookscript.yml
@@ -1,0 +1,41 @@
+---
+# Set hookscript manually because token-based auth can't do it.
+- name: Ensure snippets directory exists.
+  ansible.builtin.file:
+    path: "/var/lib/vz/snippets"
+    state: directory
+    owner: "root"
+    group: "root"
+    mode: "0755"
+
+- name: Copy hookscript to guest.
+  ansible.builtin.copy:
+    src: "{{ proxmox_lxc.hookscript }}"
+    dest: "{{ hookscript_dest }}"
+    owner: "root"
+    group: "root"
+    mode: "0755"
+  vars:
+    # Proxmox does not supports sub-directories for hookscripts,
+    # so we use the basename as path
+    hookscript_dest: >-
+      /var/lib/vz/snippets/{{ proxmox_lxc.hookscript | basename }}
+
+- name: Set hookscript of guest.
+  when: >-
+    (
+      lxc_config.hookscript |
+      default('')
+    ) != hookscript
+  ansible.builtin.command:
+    argv:
+      - pct
+      - set
+      - "{{ proxmox_lxc.vmid | ansible.builtin.mandatory }}"
+      - --hookscript
+      - "{{ hookscript }}"
+  changed_when: true
+  vars:
+    # pct expects the hookscript path in the storage format
+    hookscript: >-
+      local:snippets/{{ proxmox_lxc.hookscript | basename }}


### PR DESCRIPTION
This PR adds the ability to set a custom hookscript when creating a new LXC using the `create-lxc` Ansible Role.