### PR TITLE
Fix problems when creating/updating LXCs

### DIFF
--- a/roles/create_lxc/tasks/create.yml
+++ b/roles/create_lxc/tasks/create.yml
@@ -64,6 +64,16 @@
         api_token_secret: "{{ proxmox_api_token_secret }}"
       when: "__proxmox_is_token_setup"
 
+# Introduce a short delay (1 second) to allow Proxmox to finalize
+# the LXC creation/update process.
+# Without this delay, subsequent tasks may run before the container
+# is fully initialized, leading to intermittent failures.
+# Observed issues include startup errors and temporary SSH
+# unavailability immediately after provisioning.
+- name: Ensure LXC is properly configured before proceeding.
+  ansible.builtin.wait_for:
+    timeout: 1
+
 - name: Ensure LXC exists after its creation.
   block:
     - name: Retrieve LXC status.


### PR DESCRIPTION
This PR addresses a series of problems arising when creating a new LXC or updating an existing one.
These issues can be divided into two categories:
- playbook failures
- SSH connection failures

The former causes the playbook to fail with some error related to the `community.proxmox` collection or the Proxmox APIs when trying to start the new LXC. The latter runs the `create_lxc` role successfully, but the SSH connection to the node times out, resulting in an error.

These issues are all related to the speed of task execution. Creating multiple LXCs in a loop only exacerbates these issues, resulting in race conditions.
Adding a small delay after creating/updating the LXC seems to fix the problem, giving Proxmox time to finish configuring the container before proceeding with the role.

This PR closes #100, #83, #84, and #63