### PR TITLE
Configure DNS global parameters in inventory

### DIFF
--- a/inventory/group_vars/all/dns.yml
+++ b/inventory/group_vars/all/dns.yml
@@ -1,0 +1,6 @@
+---
+dns:
+  search_domains:
+    - "{{ network.domain | ansible.builtin.mandatory }}"
+  servers:
+    - "{{ network.ip4 | ansible.utils.nthhost(1) | ansible.builtin.mandatory }}"

--- a/inventory/host_vars/caddy/proxmox.yml
+++ b/inventory/host_vars/caddy/proxmox.yml
@@ -20,6 +20,8 @@ proxmox_lxc:
       }},gw={{
         network.gw4
       }},bridge=vmbr0
+  nameserver: "{{ dns.servers | join(',') }}"
+  searchdomain: "{{ dns.search_domains | join(',') }}"
   features:
     - "keyctl=1"
     - "nesting=1"

--- a/inventory/host_vars/docker/proxmox.yml
+++ b/inventory/host_vars/docker/proxmox.yml
@@ -20,6 +20,8 @@ proxmox_lxc:
       }},gw={{
         network.gw4
       }},bridge=vmbr0
+  nameserver: "{{ dns.servers | join(',') }}"
+  searchdomain: "{{ dns.search_domains | join(',') }}"
   features:
     - "keyctl=1"
     - "nesting=1"

--- a/inventory/host_vars/grafana/proxmox.yml
+++ b/inventory/host_vars/grafana/proxmox.yml
@@ -20,6 +20,8 @@ proxmox_lxc:
       }},gw={{
         network.gw4
       }},bridge=vmbr0
+  nameserver: "{{ dns.servers | join(',') }}"
+  searchdomain: "{{ dns.search_domains | join(',') }}"
   features:
     - "keyctl=1"
     - "nesting=1"

--- a/inventory/host_vars/influxdb/proxmox.yml
+++ b/inventory/host_vars/influxdb/proxmox.yml
@@ -20,6 +20,8 @@ proxmox_lxc:
       }},gw={{
         network.gw4
       }},bridge=vmbr0
+  nameserver: "{{ dns.servers | join(',') }}"
+  searchdomain: "{{ dns.search_domains | join(',') }}"
   features:
     - "keyctl=1"
     - "nesting=1"

--- a/inventory/host_vars/ntfy/proxmox.yml
+++ b/inventory/host_vars/ntfy/proxmox.yml
@@ -20,6 +20,8 @@ proxmox_lxc:
       }},gw={{
         network.gw4
       }},bridge=vmbr0
+  nameserver: "{{ dns.servers | join(',') }}"
+  searchdomain: "{{ dns.search_domains | join(',') }}"
   features:
     - "keyctl=1"
     - "nesting=1"


### PR DESCRIPTION
This PR adds a global `dns` dictionary to the inventory for configuring the DNS options that apply to all the hosts