### PR TITLE
Make variables mandatory in influxdb2

### DIFF
--- a/roles/influxdb2/README.md
+++ b/roles/influxdb2/README.md
@@ -5,7 +5,7 @@ An Ansible Role that installs and configure [InfluxDB 2](https://influxdata.com)
 The role manages:
 
 - InfluxDB 2 installation
-- Initial setup (organization, bucket, admin user, token)
+- Basic installation (main organization, bucket, admin user, token)
 - Creation of additional organizations, users, and buckets
 
 ## Requirements
@@ -16,14 +16,14 @@ None.
 
 Available variables are listed below, along with default values (see `defaults/main.yml` for a complete list):
 
-| Name | Type | Default | Description |
-| - | - | - | - |
-| `influxdb2_host` | string | `"http://localhost:8086"` | URL of the InfluxDB APIs. |
-| `influxdb2_primary_username` | string | `"example-user"` | Admin user created during setup. |
-| `influxdb2_primary_password` | string | `"password123"` | Password of the admin user. |
-| `influxdb2_primary_org` | string | `"example-org"` | Name of the primary organization created during setup. |
-| `influxdb2_primary_bucket` | string | `"example-bucket"` | Name of the primary bucket created during setup. |
-| `influxdb2_admin_token` | string | `"ExampleToken"` | Admin operator token. |
+| Name | Required | Type | Default | Description |
+| - | - | - | - | - |
+| `influxdb2_host` | | string | `"http://localhost:8086"` | URL of the InfluxDB APIs. |
+| `influxdb2_primary_username` | Yes | string | | Admin user created during setup. |
+| `influxdb2_primary_password` | Yes | string | | Password of the admin user. |
+| `influxdb2_primary_org` | Yes | string | | Name of the primary organization created during setup. |
+| `influxdb2_primary_bucket` | Yes | string | | Name of the primary bucket created during setup. |
+| `influxdb2_admin_token` | Yes | string | | Admin operator token. |
 | `influxdb2_orgs` | object | `[]` | Additional organizations. |
 | `influxdb2_users` | object | `[]` | Additional users. |
 | `influxdb2_buckets` | object | `[]` | Additional buckets. |

--- a/roles/influxdb2/defaults/main.yml
+++ b/roles/influxdb2/defaults/main.yml
@@ -2,15 +2,6 @@
 # URL of the InfluxDB APIs
 influxdb2_host: "http://localhost:8086"
 
-# Primary user, organization, and bucket
-influxdb2_primary_org: "example-org"
-influxdb2_primary_bucket: "example-bucket"
-influxdb2_primary_username: "example-user"
-influxdb2_primary_password: "password123"
-
-# Admin operator token
-influxdb2_admin_token: "ExampleToken"
-
 # Additional organizations
 # influxdb2_orgs:
 #   - name: org1

--- a/roles/influxdb2/tasks/configure.yml
+++ b/roles/influxdb2/tasks/configure.yml
@@ -12,11 +12,11 @@
   ansible.builtin.command: >-
     influx setup
     --host "{{ influxdb2_host }}"
-    --org {{ influxdb2_primary_org }}
-    --bucket {{ influxdb2_primary_bucket }}
-    --username {{ influxdb2_primary_username }}
-    --password {{ influxdb2_primary_password }}
-    --token {{ influxdb2_admin_token }}
+    --org {{ influxdb2_primary_org | ansible.builtin.mandatory }}
+    --bucket {{ influxdb2_primary_bucket | ansible.builtin.mandatory }}
+    --username {{ influxdb2_primary_username | ansible.builtin.mandatory }}
+    --password {{ influxdb2_primary_password | ansible.builtin.mandatory }}
+    --token {{ influxdb2_admin_token | ansible.builtin.mandatory }}
     --force
   register: __influxdb2_setup_result
   failed_when:


### PR DESCRIPTION
This PR changes some variables inside the `influxdb2` role from having a default value to being mandatory. 

The affected variables are:

- influxdb2_primary_org
- influxdb2_primary_bucket
- influxdb2_primary_username
- influxdb2_primary_password
- influxdb2_admin_token

Since they are used for configuring the default instance of InfluxDB, it is better not to use a default value, but crash the configuration process instead.