### PR TITLE
Replace `maxhoesel.caddy` collection and install Caddy manually

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -4,5 +4,4 @@ collections:
   - ansible.utils
   - community.general
   - community.proxmox
-  - maxhoesel.caddy
   - grafana.grafana

--- a/roles/caddy/README.md
+++ b/roles/caddy/README.md
@@ -35,7 +35,7 @@ Available variables are listed below, along with default values (see `defaults/m
 
 ## Dependencies
 
-This role depends on the collection `maxhoesel.caddy` for installing and managing the Caddy service itself.
+None.
 
 ## Example Playbook
 

--- a/roles/caddy/meta/main.yml
+++ b/roles/caddy/meta/main.yml
@@ -11,6 +11,17 @@ galaxy_info:
       versions:
         - bullseye
         - bookworm
+    - name: EL
+      versions:
+        - all
+    - name: Fedora
+      versions:
+        - all
+    - name: Ubuntu
+      versions:
+        - focal
+        - jammy
+        - noble
   galaxy_tags:
     - caddy
     - reverse

--- a/roles/caddy/tasks/install.yml
+++ b/roles/caddy/tasks/install.yml
@@ -1,0 +1,21 @@
+---
+# This part of the role is taken from:
+# https://github.com/maxhoesel-ansible/ansible-collection-caddy/blob/main/roles/caddy_server/tasks/install.yml
+- name: Install package requirements.
+  ansible.builtin.package:
+    name: "{{ caddy_requirements }}"
+
+- name: Perform distro-specific setup.
+  ansible.builtin.include_tasks: "setup-{{ ansible_facts.os_family }}.yml"
+
+- name: Install Caddy packages.
+  ansible.builtin.package:
+    name: "{{ caddy_packages }}"
+    state: present
+  notify: restart caddy service
+
+- name: Start and enable Caddy service at boot.
+  ansible.builtin.service:
+    name: "{{ caddy_service }}"
+    enabled: true
+    state: started

--- a/roles/caddy/tasks/main.yml
+++ b/roles/caddy/tasks/main.yml
@@ -1,12 +1,17 @@
 ---
-- name: Install Caddy.
-  ansible.builtin.import_role:
-    name: maxhoesel.caddy.caddy_server
+- name: Load OS-specific vars.
+  ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
   vars:
-    caddy_apply_config: false
+    params:
+      files:
+        - "{{ ansible_distribution }}.yml"
+        - "{{ ansible_os_family }}.yml"
+        - main.yml
+      paths:
+        - "vars"
 
-- name: Ensure handlers are notified now to avoid conflicts.
-  ansible.builtin.meta: flush_handlers
+- name: Install Caddy service.
+  ansible.builtin.import_tasks: install.yml
 
 - name: Configure Caddy.
   ansible.builtin.import_tasks: configure.yml

--- a/roles/caddy/tasks/setup-Debian.yml
+++ b/roles/caddy/tasks/setup-Debian.yml
@@ -1,0 +1,36 @@
+# This role previously used the old sources.list repository style with a separate key in the keyring.
+# This has been superseded by the deb822-based approach, but we still need to clean up after ourselves.
+- name: Key is absent from old apt-key store.
+  ansible.builtin.apt_key:
+    id: 65760C51EDEA2017CEA2CA15155B6D79CA56EA34
+    state: absent
+  when: >
+    ansible_distribution == "Debian" and ansible_distribution_major_version is version('12', '<=') or
+    ansible_distribution == "Ubuntu" and ansible_distribution_version is version('24.04', '<=')
+
+- name: Old repository definition is absent.
+  ansible.builtin.file:
+    path: /etc/apt/sources.list.d/dl_cloudsmith_io_public_caddy_stable_deb_debian.list
+    state: absent
+
+- name: Python3-debian package is present.
+  ansible.builtin.apt:
+    name:
+      - python3-debian
+
+- name: Caddy repository is configured.
+  ansible.builtin.deb822_repository:
+    name: caddy-stable
+    uris: "{{ caddy_apt_repo_url }}"
+    types:
+      - "deb"
+      - "deb-src"
+    enabled: true
+    suites: "any-version"
+    components:
+      - "main"
+    signed_by: "{{ caddy_apt_key_url }}"
+
+- name: Update repository cache.
+  ansible.builtin.apt:
+    update_cache: true

--- a/roles/caddy/tasks/setup-RedHat.yml
+++ b/roles/caddy/tasks/setup-RedHat.yml
@@ -1,0 +1,8 @@
+---
+- name: Caddy repository is enabled.
+  ansible.builtin.yum_repository:
+    name: caddy
+    description: Caddy server repo
+    baseurl: "{{ caddy_rpm_repo }}"
+    skip_if_unavailable: true
+    gpgkey: "{{ caddy_rpm_key }}"

--- a/roles/caddy/vars/Debian.yml
+++ b/roles/caddy/vars/Debian.yml
@@ -1,0 +1,14 @@
+---
+caddy_requirements:
+  - debian-keyring
+  - debian-archive-keyring
+  - apt-transport-https
+  - python3-requests
+
+caddy_packages:
+  - caddy
+
+caddy_service: caddy
+
+caddy_apt_repo_url: https://dl.cloudsmith.io/public/caddy/stable/deb/debian
+caddy_apt_key_url: "https://dl.cloudsmith.io/public/caddy/stable/gpg.key"

--- a/roles/caddy/vars/RedHat.yml
+++ b/roles/caddy/vars/RedHat.yml
@@ -1,0 +1,14 @@
+---
+caddy_requirements:
+  - python3-requests
+
+caddy_packages:
+  - caddy
+
+caddy_service: caddy
+
+caddy_rpm_repo: >-
+  https://download.copr.fedorainfracloud.org/results/@caddy/caddy/{{
+    'fedora' if ansible_distribution | lower == 'fedora' else 'epel'
+  }}-$releasever-$basearch/"
+caddy_rpm_key: "https://download.copr.fedorainfracloud.org/results/@caddy/caddy/pubkey.gpg"


### PR DESCRIPTION
This PR removes the `maxhoesel.caddy` collection and replaces it with a manual installation of the Caddy service. 

This collection caused Ansible to fail during playbook execution, even on hosts that were not using the role, making it unreliable for this setup.