### PR TITLE
Gather facts for all hosts before playbook runs and enable facts cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
-# -- IDE ---
+# --- IDE ---
 .ropeproject
 .vscode
 
 # --- Ansible ---
 .ansible
+.ansible_facts_cache
 
 # --- Ansible secrets ---
 .vault-password

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -3,3 +3,9 @@ nocows=True
 inventory=./inventory
 interpreter_python=auto_silent
 vault_password_file=.vault-password
+
+# Cache facts
+fact_caching = jsonfile
+fact_caching_connection = .ansible_facts_cache
+# 24h
+fact_caching_timeout = 86400

--- a/playbooks/linux.yml
+++ b/playbooks/linux.yml
@@ -2,6 +2,7 @@
 - name: Configure Linux systems.
   hosts: all:!pvenodes
   become: true
+  gather_facts: false
   tags: linux
   roles:
     - role: roles/system_locale

--- a/playbooks/main.yml
+++ b/playbooks/main.yml
@@ -1,4 +1,16 @@
 ---
+- name: Gather fact for all hosts.
+  hosts: all
+  gather_facts: false
+  become: true
+  tags: always
+  tasks:
+    - name: Gather fact for host that do not have disable_fact_gathering=true.
+      when: >-
+        disable_fact_gathering is not defined or
+        disable_fact_gathering is defined and not disable_fact_gathering | bool
+      ansible.builtin.setup:
+
 - name: Import Proxmox configuration playbook.
   ansible.builtin.import_playbook: proxmox.yml
 
@@ -8,6 +20,7 @@
 - name: Configure dns server.
   hosts: dns
   become: true
+  gather_facts: false
   roles:
     - role: roles/adguardhome
       tags: dns
@@ -15,6 +28,7 @@
 - name: Configure reverse proxy.
   hosts: caddy
   become: true
+  gather_facts: false
   tags: caddy
   pre_tasks:
     - name: Generate 'caddy_site' variable from dynamic services.
@@ -34,6 +48,7 @@
 - name: Services hosted on Docker.
   hosts: docker
   become: true
+  gather_facts: false
   roles:
     - role: geerlingguy.docker
       tags: docker
@@ -45,6 +60,7 @@
 - name: Configure Grafana.
   hosts: grafana
   become: true
+  gather_facts: false
   roles:
     - role: grafana.grafana.grafana
       tags: grafana
@@ -52,6 +68,7 @@
 - name: Configure InfluxDB.
   hosts: influxdb
   become: true
+  gather_facts: false
   roles:
     - role: roles/influxdb2
       tags: influxdb
@@ -59,6 +76,7 @@
 - name: Configure NTFY.
   hosts: ntfy
   become: true
+  gather_facts: false
   roles:
     - role: roles/ntfy
       tags: ntfy

--- a/playbooks/proxmox.yml
+++ b/playbooks/proxmox.yml
@@ -2,6 +2,7 @@
 - name: Create Proxmox LXCs.
   hosts: pvenodes
   become: true
+  gather_facts: false
   tags:
     - proxmox
     - lxc


### PR DESCRIPTION
This PR adds a new play gathering facts for all hosts before running all the other plays. The facts are cached locally to avoid re-gathering them on subsequent playbook runs.