### PR TITLE
Split facts gathering for physical and virtual hosts

### DIFF
--- a/playbooks/main.yml
+++ b/playbooks/main.yml
@@ -1,18 +1,26 @@
 ---
-- name: Gather fact for all hosts.
-  hosts: all
+- name: Gather facts for all physical hosts.
+  hosts: all:!lxcs
   gather_facts: false
   become: true
   tags: always
   tasks:
-    - name: Gather fact for host that do not have disable_fact_gathering=true.
-      when: >-
-        disable_fact_gathering is not defined or
-        disable_fact_gathering is defined and not disable_fact_gathering | bool
+    - name: Gather facts for physical hosts that do not have disable_fact_gathering=true.
+      when: not disable_fact_gathering | default(false) | bool
       ansible.builtin.setup:
 
 - name: Import Proxmox configuration playbook.
   ansible.builtin.import_playbook: proxmox.yml
+
+- name: Gather facts for all virtual hosts.
+  hosts: lxcs
+  gather_facts: false
+  become: true
+  tags: always
+  tasks:
+    - name: Gather facts for virtual hosts that do not have disable_fact_gathering=true.
+      when: not disable_fact_gathering | default(false) | bool
+      ansible.builtin.setup:
 
 - name: Import Linux configuration playbook.
   ansible.builtin.import_playbook: linux.yml


### PR DESCRIPTION
This PR splits fact gathering into two stages. At the beginning of the playbook, a play gathers facts for all physical hosts; then, after the Proxmox VMs are created, another play gathers facts for all the virtual hosts.

Splitting the fact-gathering logic in two ensures Ansible will never skip plays for any host because they were not present during the first fact gathering.