### PR TITLE
Move plays from `main.yml` into service-related playbooks

### DIFF
--- a/.ansible-lint-ignore
+++ b/.ansible-lint-ignore
@@ -3,8 +3,11 @@
 # Playbooks violations
 playbooks/linux.yml role-name[path]
 playbooks/main.yml role-name[path]
+playbooks/monitoring.yml role-name[path]
+playbooks/networking.yml role-name[path]
 playbooks/proxmox.yml var-naming[no-role-prefix]
 playbooks/proxmox.yml role-name[path]
+playbooks/services.yml role-name[path]
 
 # Proxmox-related violations
 roles/create_lxc/defaults/main.yml var-naming[no-role-prefix]

--- a/playbooks/main.yml
+++ b/playbooks/main.yml
@@ -25,68 +25,11 @@
 - name: Import Linux configuration playbook.
   ansible.builtin.import_playbook: linux.yml
 
-- name: Configure dns server.
-  hosts: mercury-dns
-  become: true
-  gather_facts: false
-  roles:
-    - role: roles/adguardhome
-      tags: dns
+- name: Import Networking services playbook.
+  ansible.builtin.import_playbook: networking.yml
 
-- name: Configure reverse proxy.
-  hosts: mars-proxy
-  become: true
-  gather_facts: false
-  tags: caddy
-  pre_tasks:
-    - name: Generate 'caddy_site' variable from dynamic services.
-      ansible.builtin.set_fact:
-        caddy_sites: >-
-          {{
-            groups['all'] |
-            map('ansible.builtin.extract', hostvars) |
-            selectattr('caddy_sites', 'defined') |
-            map(attribute='caddy_sites') |
-            list |
-            flatten
-          }}
-  roles:
-    - role: roles/caddy
+- name: Import Monitoring services playbook.
+  ansible.builtin.import_playbook: monitoring.yml
 
-- name: Services hosted on Docker.
-  hosts: earth-docker
-  become: true
-  gather_facts: false
-  roles:
-    - role: geerlingguy.docker
-      tags: docker
-    - role: roles/ddns
-      tags: ddns
-    - role: roles/vaultwarden
-      tags: vaultwarden
-    - role: roles/portfolio
-      tags: portfolio
-
-- name: Configure Grafana.
-  hosts: grafana
-  become: true
-  gather_facts: false
-  roles:
-    - role: grafana.grafana.grafana
-      tags: grafana
-
-- name: Configure InfluxDB.
-  hosts: influxdb
-  become: true
-  gather_facts: false
-  roles:
-    - role: roles/influxdb2
-      tags: influxdb
-
-- name: Configure NTFY.
-  hosts: ntfy
-  become: true
-  gather_facts: false
-  roles:
-    - role: roles/ntfy
-      tags: ntfy
+- name: Import other services playbook.
+  ansible.builtin.import_playbook: services.yml

--- a/playbooks/main.yml
+++ b/playbooks/main.yml
@@ -9,7 +9,7 @@
       when: not (disable_fact_gathering | default(false) | bool)
       ansible.builtin.setup:
 
-- name: Import Proxmox configuration playbook.
+- name: Configure Proxmox hosts and LXCs.
   ansible.builtin.import_playbook: proxmox.yml
 
 - name: Gather facts for all virtual hosts.
@@ -22,14 +22,14 @@
       when: not (disable_fact_gathering | default(false) | bool)
       ansible.builtin.setup:
 
-- name: Import Linux configuration playbook.
+- name: Configure all Linux systems.
   ansible.builtin.import_playbook: linux.yml
 
-- name: Import Networking services playbook.
+- name: Configure networking services.
   ansible.builtin.import_playbook: networking.yml
 
-- name: Import Monitoring services playbook.
+- name: Configure monitoring services.
   ansible.builtin.import_playbook: monitoring.yml
 
-- name: Import other services playbook.
+- name: Configure other services.
   ansible.builtin.import_playbook: services.yml

--- a/playbooks/monitoring.yml
+++ b/playbooks/monitoring.yml
@@ -1,0 +1,24 @@
+---
+- name: Configure Grafana.
+  hosts: grafana
+  become: true
+  gather_facts: false
+  roles:
+    - role: grafana.grafana.grafana
+      tags: grafana
+
+- name: Configure InfluxDB.
+  hosts: influxdb
+  become: true
+  gather_facts: false
+  roles:
+    - role: roles/influxdb2
+      tags: influxdb
+
+- name: Configure NTFY.
+  hosts: ntfy
+  become: true
+  gather_facts: false
+  roles:
+    - role: roles/ntfy
+      tags: ntfy

--- a/playbooks/networking.yml
+++ b/playbooks/networking.yml
@@ -1,0 +1,28 @@
+---
+- name: Configure dns server.
+  hosts: mercury-dns
+  become: true
+  gather_facts: false
+  roles:
+    - role: roles/adguardhome
+      tags: dns
+
+- name: Configure reverse proxy.
+  hosts: mars-proxy
+  become: true
+  gather_facts: false
+  tags: caddy
+  pre_tasks:
+    - name: Generate 'caddy_site' variable from dynamic services.
+      ansible.builtin.set_fact:
+        caddy_sites: >-
+          {{
+            groups['all'] |
+            map('ansible.builtin.extract', hostvars) |
+            selectattr('caddy_sites', 'defined') |
+            map(attribute='caddy_sites') |
+            list |
+            flatten
+          }}
+  roles:
+    - role: roles/caddy

--- a/playbooks/services.yml
+++ b/playbooks/services.yml
@@ -1,0 +1,14 @@
+---
+- name: Configure services hosted on Docker.
+  hosts: earth-docker
+  become: true
+  gather_facts: false
+  roles:
+    - role: geerlingguy.docker
+      tags: docker
+    - role: roles/ddns
+      tags: ddns
+    - role: roles/vaultwarden
+      tags: vaultwarden
+    - role: roles/portfolio
+      tags: portfolio


### PR DESCRIPTION
In this PR, all service-related plays previously in the `main.yml` playbook are moved to more specific playbooks. 
The new playbooks are: 
- `networking.yml` 
- `monitoring.yml`
- `services.yml`