### PR TITLE
Fix Ansible Lint role-name[path] violations

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,5 +1,6 @@
 exclude_paths:
-  - inventory/*.vault.yml
+  - .ansible
+  - .github
 
 enable_list:
   - loop-var-prefix

--- a/.ansible-lint-ignore
+++ b/.ansible-lint-ignore
@@ -1,18 +1,7 @@
 # This file contains ignores rule violations for ansible-lint
 
-# Playbooks violations
-playbooks/linux.yml role-name[path]
-playbooks/main.yml role-name[path]
-playbooks/monitoring.yml role-name[path]
-playbooks/networking.yml role-name[path]
-playbooks/proxmox.yml var-naming[no-role-prefix]
-playbooks/proxmox.yml role-name[path]
-playbooks/services.yml role-name[path]
-
 # Proxmox-related violations
+# This violations are related to `proxmox_` variables that do not follow
+# the roles' naming conventions.
+playbooks/proxmox.yml var-naming[no-role-prefix]
 roles/create_lxc/defaults/main.yml var-naming[no-role-prefix]
-
-# Docker-related violations
-roles/ddns/tasks/main.yml role-name[path]
-roles/vaultwarden/tasks/main.yml role-name[path]
-roles/portfolio/tasks/main.yml role-name[path]

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,6 +1,8 @@
 [defaults]
 nocows=True
 inventory=./inventory
+roles_path=.ansible/roles:roles
+collections_path=.ansible/collections
 interpreter_python=auto_silent
 vault_password_file=.vault-password
 

--- a/playbooks/linux.yml
+++ b/playbooks/linux.yml
@@ -5,14 +5,14 @@
   gather_facts: false
   tags: linux
   roles:
-    - role: roles/system_locale
+    - role: system_locale
       when: ansible_facts['distribution'] != 'Alpine'
       tags: locale
-    - role: roles/system_update
+    - role: system_update
       tags: update
-    - role: roles/system_users
+    - role: system_users
       tags: users
-    - role: roles/ssh
+    - role: ssh
       tags: ssh
-    - role: roles/motd
+    - role: motd
       tags: motd

--- a/playbooks/monitoring.yml
+++ b/playbooks/monitoring.yml
@@ -12,7 +12,7 @@
   become: true
   gather_facts: false
   roles:
-    - role: roles/influxdb2
+    - role: influxdb2
       tags: influxdb
 
 - name: Configure NTFY.
@@ -20,5 +20,5 @@
   become: true
   gather_facts: false
   roles:
-    - role: roles/ntfy
+    - role: ntfy
       tags: ntfy

--- a/playbooks/networking.yml
+++ b/playbooks/networking.yml
@@ -4,7 +4,7 @@
   become: true
   gather_facts: false
   roles:
-    - role: roles/adguardhome
+    - role: adguardhome
       tags: dns
 
 - name: Configure reverse proxy.
@@ -25,4 +25,4 @@
             flatten
           }}
   roles:
-    - role: roles/caddy
+    - role: caddy

--- a/playbooks/proxmox.yml
+++ b/playbooks/proxmox.yml
@@ -34,7 +34,7 @@
   tasks:
     - name: Create LXC guests.
       ansible.builtin.include_role:
-        name: roles/create_lxc
+        name: create_lxc
       vars:
         proxmox_lxc: "{{ guest.proxmox_lxc }}"
       loop: "{{ lxc_guests }}"

--- a/playbooks/services.yml
+++ b/playbooks/services.yml
@@ -6,9 +6,9 @@
   roles:
     - role: geerlingguy.docker
       tags: docker
-    - role: roles/ddns
+    - role: ddns
       tags: ddns
-    - role: roles/vaultwarden
+    - role: vaultwarden
       tags: vaultwarden
-    - role: roles/portfolio
+    - role: portfolio
       tags: portfolio

--- a/roles/ddns/tasks/main.yml
+++ b/roles/ddns/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Deploy ddns Docker Compose stack.
   ansible.builtin.include_role:
-    name: roles/docker_compose
+    name: docker_compose
   vars:
     docker_compose_root: "{{ ddns_root }}"
     docker_compose_templates:

--- a/roles/portfolio/tasks/main.yml
+++ b/roles/portfolio/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: Deploy portfolio Docker Compose stack.
   ansible.builtin.include_role:
-    name: roles/docker_compose
+    name: docker_compose
   vars:
     docker_compose_root: "{{ portfolio_root }}"
     docker_compose_templates:

--- a/roles/vaultwarden/tasks/main.yml
+++ b/roles/vaultwarden/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Deploy vaultwarden Docker Compose stack.
   ansible.builtin.import_role:
-    name: roles/docker_compose
+    name: docker_compose
   vars:
     docker_compose_root: "{{ vaultwarden_root }}"
     docker_compose_subdirs:


### PR DESCRIPTION
This PR fixes the `role-name[path]` violations, removing the need to use the `roles` prefix before every role invocation.