### PR TITLE
Add `proxmox_validate_certs` to `create_lxc`

### DIFF
--- a/inventory/host_vars/vega/proxmox.yml
+++ b/inventory/host_vars/vega/proxmox.yml
@@ -4,6 +4,10 @@ proxmox_api_user: "{{ vault_proxmox_api_user }}"
 proxmox_api_token_id: "{{ vault_proxmox_api_token_id }}"
 proxmox_api_token_secret: "{{ vault_proxmox_api_token_secret }}"
 
+# Disable SSL certificate validation to avoid problems
+# with Proxmox API connection.
+proxmox_validate_certs: false
+
 pve_group: # No cluster.
 pve_fqdn: "{{ inventory_hostname }}.{{ network.domain | ansible.builtin.mandatory }}"
 pve_groups:

--- a/roles/create_lxc/README.md
+++ b/roles/create_lxc/README.md
@@ -45,6 +45,7 @@ These variables define how Ansible authenticates and connects to the Proxmox API
 | `proxmox_node` | Yes | string | | Proxmox host node. |
 | `proxmox_api_host` | | string | `"localhost"` | Address of the Proxmox API host. |
 | `proxmox_api_user` | Yes | string | | Proxmox API user. |
+| `proxmox_validate_certs` | | bool | | Validate the TLS certificates used for the connection to the Proxmox VE API.|
 
 For authentication you must use either password-based authentication or API tokens, not both.
 

--- a/roles/create_lxc/tasks/configure.yml
+++ b/roles/create_lxc/tasks/configure.yml
@@ -8,6 +8,7 @@
           api_host: "{{ proxmox_api_host | ansible.builtin.mandatory }}"
           api_user: "{{ proxmox_api_user | ansible.builtin.mandatory }}"
           vmid: "{{ proxmox_lxc.vmid | ansible.builtin.mandatory }}"
+          validate_certs: "{{ proxmox_validate_certs | default(omit) }}"
           config: current
       block:
         - name: Retrieve current LXC config via password.

--- a/roles/create_lxc/tasks/create.yml
+++ b/roles/create_lxc/tasks/create.yml
@@ -7,9 +7,11 @@
       node: "{{ proxmox_node | ansible.builtin.mandatory }}"
       api_host: "{{ proxmox_api_host | ansible.builtin.mandatory }}"
       api_user: "{{ proxmox_api_user | ansible.builtin.mandatory }}"
+      validate_certs: "{{ proxmox_validate_certs | default(omit) }}"
 
       state: present
       update: true
+      cmode: "tty"
 
       # Set main LXC info
       vmid: "{{ proxmox_lxc.vmid | ansible.builtin.mandatory }}"
@@ -83,6 +85,7 @@
           api_host: "{{ proxmox_api_host | ansible.builtin.mandatory }}"
           api_user: "{{ proxmox_api_user | ansible.builtin.mandatory }}"
           vmid: "{{ proxmox_lxc.vmid | ansible.builtin.mandatory }}"
+          validate_certs: "{{ proxmox_validate_certs | default(omit) }}"
       block:
         - name: Retrieve LXC status via password.
           community.proxmox.proxmox_vm_info: # noqa: args[module]

--- a/roles/create_lxc/tasks/start.yml
+++ b/roles/create_lxc/tasks/start.yml
@@ -7,6 +7,7 @@
       api_user: "{{ proxmox_api_user }}"
       vmid: "{{ proxmox_lxc.vmid }}"
       hostname: "{{ proxmox_lxc.hostname }}"
+      validate_certs: "{{ proxmox_validate_certs | default(omit) }}"
       state: started
   block:
     - name: Ensure LXC is running via password.

--- a/roles/create_lxc/tasks/template.yml
+++ b/roles/create_lxc/tasks/template.yml
@@ -9,6 +9,7 @@
       storage: "{{ proxmox_lxc.template.storage | default(omit) }}"
       content_type: "{{ proxmox_lxc.template.content_type | default(omit) }}"
       timeout: "{{ proxmox_lxc.template.timeout | default(omit) }}"
+      validate_certs: "{{ proxmox_validate_certs | default(omit) }}"
       state: present
   block:
     - name: Ensure LXC template is present via password.


### PR DESCRIPTION
This PR adds the parameter `proxmox_validate_certs` to the `create_lxc` Ansible Role. 
This parameter controls whether the Proxmox API validates SSL certificates when connecting. 

In the latest version of the `community.proxmox` role, the default changed from `false` to `true`, breaking all API usage in case valid certificates are not configured on the system.