### PR TITLE
Configure Linux baseline for Proxmox hypervisors

### DIFF
--- a/inventory/group_vars/all/ansible.yml
+++ b/inventory/group_vars/all/ansible.yml
@@ -1,2 +1,3 @@
 ---
 ansible_managed: "WARNING: This file is managed by Ansible."
+controller_ssh_pubkey: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') }}"

--- a/inventory/group_vars/all/kvm.yml
+++ b/inventory/group_vars/all/kvm.yml
@@ -3,4 +3,4 @@ kvm_default_template_name: "debian-13-cloudinit-template"
 kvm_default_template_vmid: 9001
 kvm_default_user: "{{ vault_kvm_default_user }}"
 kvm_default_password: "{{ vault_kvm_default_password }}"
-kvm_default_pubkey: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') }}"
+kvm_default_pubkey: "{{ controller_ssh_pubkey }}"

--- a/inventory/group_vars/all/locale.yml
+++ b/inventory/group_vars/all/locale.yml
@@ -1,0 +1,3 @@
+---
+system_locale_lang: "en_US.UTF-8"
+system_locale_timezone: "Europe/Rome"

--- a/inventory/group_vars/all/lxc.yml
+++ b/inventory/group_vars/all/lxc.yml
@@ -1,6 +1,6 @@
 ---
 lxc_default_password: "{{ vault_lxc_default_password }}"
-lxc_default_pubkey: "{{ lookup('ansible.builtin.file', '~/.ssh/id_rsa.pub') }}"
+lxc_default_pubkey: "{{ controller_ssh_pubkey }}"
 lxc_default_template: "debian-12-standard_12.12-1_amd64.tar.zst"
 lxc_default_template_timeout: 60
 lxc_default_hookscript: "lxc/hookscript.sh"

--- a/inventory/group_vars/hypervisor/ssh.yml
+++ b/inventory/group_vars/hypervisor/ssh.yml
@@ -1,0 +1,4 @@
+---
+# Allow pubkey authentication for the root user to avoid
+# problems with the Proxmox Web UI not working.
+ssh_permit_root_login: "prohibit-password"

--- a/inventory/group_vars/hypervisor/users.yml
+++ b/inventory/group_vars/hypervisor/users.yml
@@ -1,0 +1,16 @@
+---
+system_users:
+  # Ansible management user
+  - name: ansible
+    comment: "Ansible management user"
+    authorized_keys:
+      - "{{ controller_ssh_pubkey }}"
+    sudo_options:
+      - "ALL=(ALL) NOPASSWD: ALL"
+  # Personal admin user
+  - name: lorenzo
+    comment: "Lorenzo Calisti"
+    authorized_keys:
+      - "{{ controller_ssh_pubkey }}"
+    sudo_options:
+      - "ALL=(ALL) ALL"

--- a/playbooks/proxmox.yml
+++ b/playbooks/proxmox.yml
@@ -3,15 +3,24 @@
   hosts: hypervisor
   become: true
   gather_facts: false
+  tags:
+    - proxmox
+    - pve
   roles:
     - role: lae.proxmox
       vars:
         # Would remove Proxmox completely.
         # https://github.com/lae/ansible-role-proxmox/issues/223
         pve_remove_old_kernels: false
-      tags:
-        - proxmox
-        - pve
+      tags: pve_system
+    - role: system_locale
+      tags: locale
+    - role: system_users
+      tags: users
+    - role: ssh
+      tags: ssh
+    - role: motd
+      tags: motd
 
 - name: Create Proxmox LXCs.
   hosts: hypervisor


### PR DESCRIPTION
This PR adds Linux baseline roles (locale, users, ssh, motd) to Proxmox playbook.

Closing #143 