### PR TITLE
Fix adguardhome capabilities problems

### DIFF
--- a/inventory/host_vars/mercury-dns/adguard.yml
+++ b/inventory/host_vars/mercury-dns/adguard.yml
@@ -1,5 +1,6 @@
 ---
 adguardhome_config:
+  schema_version: 34
   http:
     address: "0.0.0.0:3000"
   users: "{{ vault_adguard_users }}"

--- a/roles/adguardhome/tasks/configure.yml
+++ b/roles/adguardhome/tasks/configure.yml
@@ -12,7 +12,7 @@
     content: "{{ adguardhome_config | to_nice_yaml }}"
     owner: "{{ adguardhome_user }}"
     group: "{{ adguardhome_group }}"
-    mode: "0644"
+    mode: "0600"
 
 - name: Start AdGuardHome service after writing config file.
   ansible.builtin.service:

--- a/roles/adguardhome/tasks/install.yml
+++ b/roles/adguardhome/tasks/install.yml
@@ -13,18 +13,28 @@
     mode: "0755"
     creates: "{{ adguardhome_bin_dir }}/AdGuardHome"
 
-- name: Allow binary to bind to ports lower than 1024 as a non-root user
+- name: Allow binary to bind to privileged ports as non-root user.
   community.general.capabilities:
     path: "{{ adguardhome_bin_file }}"
-    capability: cap_net_bind_service+eip
+    capability: "{{ __cap }}"
     state: present
+  loop:
+    - "cap_net_bind_service+eip"
+    - "cap_net_raw+eip"
+  loop_control:
+    loop_var: __cap
   when: adguardhome_user != "root"
 
-- name: Disallow binary to bind to ports lower than 1024 as a non-root user
+- name: Remove capabilities from binary when running as root.
   community.general.capabilities:
     path: "{{ adguardhome_bin_file }}"
-    capability: cap_net_bind_service+eip
+    capability: "{{ __cap }}"
     state: absent
+  loop:
+    - "cap_net_bind_service+eip"
+    - "cap_net_raw+eip"
+  loop_control:
+    loop_var: __cap
   when: adguardhome_user == "root"
 
 - name: Copy systemd service.

--- a/roles/adguardhome/tasks/main.yml
+++ b/roles/adguardhome/tasks/main.yml
@@ -15,6 +15,7 @@
     - path: "{{ adguardhome_data_dir }}"
       mode: "0700"
     - path: "{{ adguardhome_conf_dir }}"
+      mode: "0700"
   loop_control:
     label: "{{ __dir.path }}"
     loop_var: __dir

--- a/roles/adguardhome/templates/adguardhome.service.j2
+++ b/roles/adguardhome/templates/adguardhome.service.j2
@@ -16,6 +16,7 @@ Restart=always
 RestartSec=10
 StandardOutput=journal
 StandardError=journal
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_NET_RAW
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The AdGuard Hone service runs as non-root; because of this, there were problems when trying to open raw sockets on protected ports.

This PR fixes the `adguardhome` Ansible Role by adding a missing `cap_net_raw` capability to the binary and changing default permissions for some directories. 