### PR TITLE
Add configurable DNS server list for the container

### DIFF
--- a/roles/ddns/README.md
+++ b/roles/ddns/README.md
@@ -18,6 +18,7 @@ Available variables are listed below, along with default values (see `defaults/m
 |`ddns_restart` | | string | `"unless-stopped"` | Docker container restart policy. |
 |`ddns_port` | | int | `8000` | Port exposed by the DDNS service.|
 |`ddns_timezone` | | string | `"UTC"` | Timezone used by the DDNS service container. |
+|`ddns_dns_servers` | | list | `[]` | List of DNS servers for the container (e.g. `["1.1.1.1", "8.8.8.8"]`). If empty, Docker's default DNS is used. Useful when the DDNS provider requires a specific resolver. |
 
 ## Dependencies
 

--- a/roles/ddns/defaults/main.yml
+++ b/roles/ddns/defaults/main.yml
@@ -5,3 +5,4 @@ ddns_version: "latest"
 ddns_restart: "unless-stopped"
 ddns_port: 8000
 ddns_timezone: "UTC"
+ddns_dns_servers: []

--- a/roles/ddns/templates/compose.yml.j2
+++ b/roles/ddns/templates/compose.yml.j2
@@ -11,6 +11,12 @@ services:
       - "data:/updater/data"
     env_file:
       ".env"
+{% if ddns_dns_servers | length > 0 %}
+    dns:
+{% for server in ddns_dns_servers %}
+      - "{{ server }}"
+{% endfor %}
+{% endif %}
     environment:
       TZ: "{{ ddns_timezone }}"
       # TODO: Add support for notifications


### PR DESCRIPTION
This PR adds `ddns_dns_servers`.  When non-empty it injects a dns: block into the Compose service definition.