### PR TITLE
Add `hosts` role

### DIFF
--- a/playbooks/networking.yml
+++ b/playbooks/networking.yml
@@ -4,6 +4,15 @@
   become: true
   gather_facts: false
   roles:
+    - role: hosts
+      tags: hosts
+      vars:
+        hosts_domain: >-
+          {{
+            dns.search_domains |
+            ansible.builtin.first |
+            ansible.builtin.mandatory
+          }}
     - role: adguardhome
       tags: dns
 

--- a/roles/hosts/README.md
+++ b/roles/hosts/README.md
@@ -1,0 +1,37 @@
+# Ansible Role: hosts
+
+An Ansible Role that manages `/etc/hosts` with standard loopback entries and dynamic host entries from the Ansible inventory.
+
+## Requirements
+
+None.
+
+## Role Variables
+
+Available variables are listed below, along with default values (see `defaults/main.yml` for a complete list):
+
+| Name | Type | Default | Description |
+| - | - | - | - |
+| `hosts_group` | string | `all` | Inventory group to source host entries from. |
+| `hosts_domain` | string | `""` | Domain appended to hostnames. If empty, only the short hostname is written. |
+
+## Dependencies
+
+None.
+
+## Example Playbook
+
+```yaml
+- name: Configure /etc/hosts.
+  hosts: all
+  roles:
+    - role: hosts
+```
+
+## License
+
+MIT
+
+## Author Information
+
+This role was created in 2026 by Lorenzo Calisti.

--- a/roles/hosts/defaults/main.yml
+++ b/roles/hosts/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+hosts_group: "all"
+hosts_domain: ""

--- a/roles/hosts/meta/main.yml
+++ b/roles/hosts/meta/main.yml
@@ -1,0 +1,35 @@
+---
+dependencies: []
+
+galaxy_info:
+  role_name: hosts
+  author: Lorenzo Calisti
+  description: Manage /etc/hosts with inventory-based host entries.
+  license: MIT
+  min_ansible_version: "2.1"
+  platforms:
+    - name: ArchLinux
+      versions:
+        - all
+    - name: Alpine
+      versions:
+        - all
+    - name: Debian
+      versions:
+        - bullseye
+        - bookworm
+    - name: EL
+      versions:
+        - all
+    - name: Fedora
+      versions:
+        - all
+    - name: Ubuntu
+      versions:
+        - focal
+        - jammy
+        - noble
+  galaxy_tags:
+    - hosts
+    - dns
+    - networking

--- a/roles/hosts/tasks/main.yml
+++ b/roles/hosts/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+- name: Configure /etc/hosts.
+  ansible.builtin.template:
+    src: "hosts.j2"
+    dest: "/etc/hosts"
+    owner: "root"
+    group: "root"
+    mode: "0644"

--- a/roles/hosts/templates/hosts.j2
+++ b/roles/hosts/templates/hosts.j2
@@ -1,0 +1,19 @@
+{{ ansible_managed | comment }}
+
+# Loopback
+127.0.0.1 localhost
+
+# Basic IPv6 entries
+::1      localhost6.localdomain6  localhost6  ip6-localhost  ip6-loopback
+fe00::0  ip6-localnet
+ff00::0  ip6-mcastprefix
+ff02::1  ip6-allnodes
+ff02::2  ip6-allrouters
+
+# Inventory hosts
+{% for host in groups[hosts_group] | sort %}
+{% set _vars = hostvars[host] %}
+{% if _vars.ansible_host is defined %}
+{{ "{:<15}".format(_vars.ansible_host) }} {% if hosts_domain %}{{ host }}.{{ hosts_domain }} {% endif %}{{ host }}
+{% endif %}
+{% endfor %}

--- a/roles/hosts/tests/inventory
+++ b/roles/hosts/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/roles/hosts/tests/test.yml
+++ b/roles/hosts/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- name: Test hosts role.
+  hosts: localhost
+  roles:
+    - hosts


### PR DESCRIPTION
This PR introduces the `hosts` Ansible Role that generates `/etc/hosts` from the Ansible inventory.

Using this role in the main DNS service to manage a map of all the static hosts in the homelab is a solution to fixing hostname resolution for static IPs (#148). 