### PR TITLE
Add device passthrough when creating LXCs

### DIFF
--- a/roles/create_lxc/README.md
+++ b/roles/create_lxc/README.md
@@ -77,7 +77,8 @@ All container-related settings are defined inside the `proxmox_lxc` dictionary.
 | `memory` | | int | | Amount of RAM in MB. |
 | `swap` | | int | | Size of the swap memory in MB. |
 | `disk_volume` | Yes | dict | | Main disk configuration (same syntax as `community.general.proxmox`). |
-| `mount_volumes` | | dict | `{}` | Additional mount points for the LXC. |
+| `mount_volumes` | | dict | `{}` | Additional bind mount points for the LXC. See [Mount volumes](#mount-volumes). |
+| `devices` | | dict | `{}` | Device passthrough configuration for the LXC. See [Device passthrough](#device-passthrough). |
 | `netif` | | dict | `{}` | Network interfaces of the LXC (same syntax as `community.general.proxmox`). |
 | `ostype` | | string | | OS type. |
 | `onboot` | | bool | `false` | Start container on host boot. |
@@ -87,6 +88,53 @@ All container-related settings are defined inside the `proxmox_lxc` dictionary.
 | `timezone` | | string | `"host"` | Container Timezone. |
 | `features` | | list | `[]` | Additional LXC features. |
 | `tags` | | list | `["ansible"]` | Container Tags. |
+
+### Mount volumes
+
+`mount_volumes` is a dict where each key is a Proxmox mount point identifier (e.g. `mp0`) and each value defines the bind mount.
+
+| Key | Required | Description |
+| - | - | - |
+| `host_path` | Yes | Absolute path on the Proxmox host to bind-mount into the container. |
+| `mountpoint` | Yes | Absolute path inside the container where the host path is mounted. |
+
+Example:
+
+```yaml
+proxmox_lxc:
+  mount_volumes:
+    mp0:
+      host_path: /mnt/tank/media
+      mountpoint: /media
+    mp1:
+      host_path: /mnt/tank/downloads
+      mountpoint: /downloads
+```
+
+### Device passthrough
+
+`devices` is a dict where each key is a Proxmox device identifier (e.g. `dev0`) and each value defines a host device to expose inside the container.
+
+| Key | Required | Description |
+| - | - | - |
+| `path` | Yes | Absolute path of the device on the Proxmox host (e.g. `/dev/dri/renderD128`). |
+| `gid` | | Group ID to assign to the device inside the container. |
+| `uid` | | User ID to assign to the device inside the container. |
+| `mode` | | Permission mode for the device (octal). |
+| `deny_write` | | If set, deny write access to the device. |
+
+Example:
+
+```yaml
+proxmox_lxc:
+  devices:
+    dev0:
+      path: /dev/dri/renderD128
+      gid: 104
+    dev1:
+      path: /dev/dri/card0
+      gid: 44
+```
 
 ## Dependencies
 

--- a/roles/create_lxc/tasks/configure.yml
+++ b/roles/create_lxc/tasks/configure.yml
@@ -56,3 +56,6 @@
 - name: Set hookscript.
   ansible.builtin.include_tasks: hookscript.yml
   when: proxmox_lxc.hookscript is defined
+
+- name: Set device passthrough.
+  ansible.builtin.import_tasks: devices.yml

--- a/roles/create_lxc/tasks/devices.yml
+++ b/roles/create_lxc/tasks/devices.yml
@@ -1,0 +1,38 @@
+---
+# Set device passthrough manually because Proxmox APIs can't do it.
+- name: Set device passthrough.
+  when: >-
+    (
+      __lxc_current_config[__device.key] |
+      default('')
+    ) != options_string
+  ansible.builtin.command:
+    argv:
+      - pct
+      - set
+      - "{{ proxmox_lxc.vmid | ansible.builtin.mandatory }}"
+      - "-{{ __device.key }}"
+      - "{{ options_string }}"
+  loop: >-
+    {{
+      proxmox_lxc.devices |
+      default({}) |
+      ansible.builtin.dict2items
+    }}
+  loop_control:
+    label: "{{ __device.key }}={{ options_string }}"
+    loop_var: __device
+  changed_when: true
+  vars:
+    options_string: >-
+      {{
+        __device.value.path | ansible.builtin.mandatory
+      }}{{
+        ',deny-write=' ~ __device.value.deny_write if __device.value.deny_write is defined else ''
+      }}{{
+        ',gid=' ~ __device.value.gid if __device.value.gid is defined else ''
+      }}{{
+        ',uid=' ~ __device.value.uid if __device.value.uid is defined else ''
+      }}{{
+        ',mode=' ~ __device.value.mode if __device.value.mode is defined else ''
+      }}


### PR DESCRIPTION
This PR adds to the `create_lxc` role the ability to configure device passthrough when creating an LXC.