### PR TITLE
Rename roles handlers for consistency

### DIFF
--- a/roles/adguardhome/handlers/main.yml
+++ b/roles/adguardhome/handlers/main.yml
@@ -1,9 +1,9 @@
 ---
-- name: reload systemd daemon # noqa: name[casing]
+- name: adguardhome_reload_systemd # noqa: name[casing]
   ansible.builtin.systemd_service:
     daemon_reload: true
 
-- name: restart systemd-resolved # noqa: name[casing]
+- name: adguardhome_restart_systemd_resolved # noqa: name[casing]
   ansible.builtin.service:
     name: "systemd-resolved"
     state: "restarted"

--- a/roles/adguardhome/tasks/install.yml
+++ b/roles/adguardhome/tasks/install.yml
@@ -42,7 +42,7 @@
     src: adguardhome.service.j2
     dest: "/etc/systemd/system/{{ adguardhome_service_name }}.service"
     mode: "0644"
-  notify: reload systemd daemon
+  notify: adguardhome_reload_systemd
 
 - name: Ensure handlers are notified before enabling new service.
   ansible.builtin.meta: flush_handlers

--- a/roles/adguardhome/tasks/resolved.yml
+++ b/roles/adguardhome/tasks/resolved.yml
@@ -22,7 +22,7 @@
   loop_control:
     label: "{{ __opt.option }}={{ __opt.value }}"
     loop_var: __opt
-  notify: restart systemd-resolved
+  notify: adguardhome_restart_systemd_resolved
 
 - name: Symlink '/etc/resolv.conf' to '/run/systemd/resolve/resolv.conf'.
   ansible.builtin.file:
@@ -30,7 +30,7 @@
     dest: /etc/resolv.conf
     state: link
     force: true
-  notify: restart systemd-resolved
+  notify: adguardhome_restart_systemd_resolved
 
 - name: Ensure handlers are notified now to avoid conflicts.
   ansible.builtin.meta: flush_handlers

--- a/roles/caddy/handlers/main.yml
+++ b/roles/caddy/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: restart caddy service # noqa: name[casing]
+- name: caddy_restart_service # noqa: name[casing]
   # TODO: Reload caddy instead of restarting it on configuration changes.
   #   To avoid downtime, the [docs](https://caddyserver.com/docs/running#using-the-service) suggest to
   #   reload the caddy service instead of restarting it.

--- a/roles/caddy/tasks/cleanup_sites.yml
+++ b/roles/caddy/tasks/cleanup_sites.yml
@@ -18,7 +18,7 @@
   ansible.builtin.file:
     path: "{{ __file.path }}"
     state: "absent"
-  notify: restart caddy service
+  notify: caddy_restart_service
   when: "(__file.path | basename) not in __caddy_valid_sites"
   loop: "{{ __caddy_existing_sites.files | default([]) }}"
   loop_control:

--- a/roles/caddy/tasks/cleanup_snippets.yml
+++ b/roles/caddy/tasks/cleanup_snippets.yml
@@ -18,7 +18,7 @@
   ansible.builtin.file:
     path: "{{ __file.path }}"
     state: absent
-  notify: restart caddy service
+  notify: caddy_restart_service
   when: (__file.path | basename) not in __caddy_valid_snippets
   loop: "{{ __caddy_existing_snippets.files | default([]) }}"
   loop_control:

--- a/roles/caddy/tasks/configure.yml
+++ b/roles/caddy/tasks/configure.yml
@@ -29,7 +29,7 @@
     owner: "{{ caddy_user }}"
     group: "{{ caddy_group }}"
     mode: "0644"
-  notify: restart caddy service
+  notify: caddy_restart_service
   loop: "{{ caddy_snippets }}"
   loop_control:
     label: "{{ caddy_snippet_item | basename }}"
@@ -42,7 +42,7 @@
     owner: "{{ caddy_user }}"
     group: "{{ caddy_group }}"
     mode: "0644"
-  notify: restart caddy service
+  notify: caddy_restart_service
 
 - name: Write Caddy site configs.
   ansible.builtin.copy:
@@ -51,7 +51,7 @@
     owner: "{{ caddy_user }}"
     group: "{{ caddy_group }}"
     mode: "0644"
-  notify: restart caddy service
+  notify: caddy_restart_service
   loop: "{{ caddy_sites }}"
   loop_control:
     label: "{{ caddy_site_item.name }}"

--- a/roles/caddy/tasks/install-package.yml
+++ b/roles/caddy/tasks/install-package.yml
@@ -44,4 +44,4 @@
   ansible.builtin.package:
     name: "{{ caddy_packages }}"
     state: present
-  notify: restart caddy service
+  notify: caddy_restart_service

--- a/roles/caddy/tasks/install-xcaddy.yml
+++ b/roles/caddy/tasks/install-xcaddy.yml
@@ -99,7 +99,7 @@
     PATH: "{{ caddy_go_install_dir }}/bin:/usr/local/bin:{{ ansible_facts['env']['PATH'] }}"
   when: __caddy_xcaddy_build_spec is changed or not __caddy_binary.stat.exists
   changed_when: true
-  notify: restart caddy service
+  notify: caddy_restart_service
 
 - name: Install Caddy systemd service.
   ansible.builtin.template:
@@ -108,7 +108,7 @@
     owner: root
     group: root
     mode: "0644"
-  notify: restart caddy service
+  notify: caddy_restart_service
 
 - name: Reload systemd daemon.
   ansible.builtin.systemd:

--- a/roles/jellyfin/handlers/main.yml
+++ b/roles/jellyfin/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
-- name: update apt cache # noqa: name[casing]
+- name: jellyfin_update_apt_cache # noqa: name[casing]
   ansible.builtin.apt:
     update_cache: true

--- a/roles/jellyfin/tasks/hwaccel.yml
+++ b/roles/jellyfin/tasks/hwaccel.yml
@@ -21,7 +21,7 @@
           {{ ansible_facts['distribution_release'] }}-updates
         components: non-free
         state: present
-      notify: update apt cache
+      notify: jellyfin_update_apt_cache
 
     - name: Flush handlers.
       ansible.builtin.meta: flush_handlers

--- a/roles/jellyfin/tasks/setup-Debian.yml
+++ b/roles/jellyfin/tasks/setup-Debian.yml
@@ -36,7 +36,7 @@
     architectures: "{{ jellyfin_apt_arch }}"
     signed_by: "{{ jellyfin_apt_key_path }}"
     state: present
-  notify: update apt cache
+  notify: jellyfin_update_apt_cache
 
 - name: Flush handlers.
   ansible.builtin.meta: flush_handlers

--- a/roles/ntfy/handlers/main.yml
+++ b/roles/ntfy/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: restart ntfy service # noqa: name[casing]
+- name: ntfy_restart_service # noqa: name[casing]
   ansible.builtin.service:
     name: "{{ ntfy_service_name }}"
     state: "restarted"

--- a/roles/ntfy/tasks/configure.yml
+++ b/roles/ntfy/tasks/configure.yml
@@ -14,4 +14,4 @@
     owner: "{{ ntfy_user }}"
     group: "{{ ntfy_group }}"
     mode: "0600"
-  notify: restart ntfy service
+  notify: ntfy_restart_service

--- a/roles/ntfy/tasks/setup.yml
+++ b/roles/ntfy/tasks/setup.yml
@@ -18,7 +18,7 @@
   ansible.builtin.package:
     name: "{{ ntfy_service_name }}"
     state: "present"
-  notify: restart ntfy service
+  notify: ntfy_restart_service
 
 - name: Ensure NTFY is started and enabled at boot.
   ansible.builtin.service:

--- a/roles/ssh/handlers/main.yml
+++ b/roles/ssh/handlers/main.yml
@@ -1,10 +1,10 @@
 ---
-- name: reload systemd # noqa: name[casing]
+- name: ssh_reload_systemd # noqa: name[casing]
   ansible.builtin.systemd_service:
     daemon_reload: true
   when: ansible_facts['service_mgr'] == "systemd"
 
-- name: restart ssh # noqa: name[casing]
+- name: ssh_restart_service # noqa: name[casing]
   ansible.builtin.service:
     name: "{{ ssh_sshd_name }}"
     state: "restarted"

--- a/roles/ssh/tasks/main.yml
+++ b/roles/ssh/tasks/main.yml
@@ -44,8 +44,8 @@
   loop_control:
     loop_var: __config_line
   notify:
-    - reload systemd
-    - restart ssh
+    - ssh_reload_systemd
+    - ssh_restart_service
 
 - name: Add configured users allowed to connect over ssh.
   ansible.builtin.lineinfile:
@@ -57,7 +57,7 @@
     validate: "sshd -T -f %s"
     mode: "0644"
   when: ssh_allowed_users | length > 0
-  notify: restart ssh
+  notify: ssh_restart_service
 
 - name: Add configured groups allowed to connect over ssh.
   ansible.builtin.lineinfile:
@@ -69,4 +69,4 @@
     validate: "sshd -T -f %s"
     mode: "0644"
   when: ssh_allowed_groups | length > 0
-  notify: restart ssh
+  notify: ssh_restart_service

--- a/roles/system_update/handlers/main.yml
+++ b/roles/system_update/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
-- name: reboot system # noqa: name[casing]
+- name: system_update_reboot_system # noqa: name[casing]
   ansible.builtin.reboot:
   when: system_update_reboot | bool

--- a/roles/system_update/tasks/apk.yml
+++ b/roles/system_update/tasks/apk.yml
@@ -21,4 +21,4 @@
 - name: Upgrade packages.
   community.general.apk:
     upgrade: true
-  notify: reboot system
+  notify: system_update_reboot_system

--- a/roles/system_update/tasks/apt.yml
+++ b/roles/system_update/tasks/apt.yml
@@ -21,7 +21,7 @@
 - name: Upgrade packages.
   ansible.builtin.apt:
     upgrade: "{{ system_update_apt_upgrade_type }}"
-  notify: reboot system
+  notify: system_update_reboot_system
 
 - name: Remove unused dependency packages.
   when: system_update_autoremove | bool

--- a/roles/system_update/tasks/dnf.yml
+++ b/roles/system_update/tasks/dnf.yml
@@ -22,7 +22,7 @@
   ansible.builtin.package:
     name: "*"
     state: "latest" # noqa: package-latest
-  notify: reboot system
+  notify: system_update_reboot_system
 
 - name: Remove unused dependency packages.
   when: system_update_autoremove | bool

--- a/roles/system_update/tasks/pacman.yml
+++ b/roles/system_update/tasks/pacman.yml
@@ -21,4 +21,4 @@
 - name: Upgrade packages.
   community.general.pacman:
     upgrade: true
-  notify: reboot system
+  notify: system_update_reboot_system


### PR DESCRIPTION
This PR renames all handler tasks inside roles to have a consistent naming format. The task includes the role's name as a prefix, followed by a brief description (two/three words), all in snake_case.