### PR TITLE
Mount shared data and configure group mapping in the LXCs

### DIFF
--- a/inventory/production/group_vars/hypervisor/users.yml
+++ b/inventory/production/group_vars/hypervisor/users.yml
@@ -1,4 +1,8 @@
 ---
+system_groups:
+  - name: "media"
+    gid: 2000
+
 system_users:
   # Ansible management user
   - name: ansible
@@ -19,3 +23,13 @@ system_users:
       - "{{ controller_ssh_pubkey }}"
     sudo_options:
       - "ALL=(ALL) ALL"
+
+  # Shared media user
+  - name: "media"
+    uid: 2000
+    comment: "Owns shared media directories"
+    group: "media"
+    password_lock: true
+    system: true
+    create_home: false
+    shell: /usr/sbin/nologin

--- a/inventory/production/host_vars/saturn-media/proxmox.yml
+++ b/inventory/production/host_vars/saturn-media/proxmox.yml
@@ -13,6 +13,10 @@ proxmox_lxc:
   disk_volume:
     storage: "{{ lxc_default_disk_storage }}"
     size: 16
+  mount_volumes:
+    mp0:
+      host_path: "/tank/media"
+      mountpoint: "/mnt/media"
   cores: 2
   memory: 2048
   devices:
@@ -34,5 +38,12 @@ proxmox_lxc:
   features:
     - "keyctl=1"
     - "nesting=1"
+  raw_config:
+    - "lxc.idmap: u 0 100000 65536"
+    - "lxc.idmap: g 0 100000 2000"
+    - "lxc.idmap: g 2000 2000 1"
+    - "lxc.idmap: g 2001 102001 63535"
+  subgid:
+    - "root:2000:1"
   tags:
     - "media"

--- a/inventory/production/host_vars/saturn-media/users.yml
+++ b/inventory/production/host_vars/saturn-media/users.yml
@@ -1,5 +1,15 @@
 ---
-# Ensure render group exist for iGPU passthrough
 system_groups:
+  # Ensure render group exist for iGPU passthrough
   - name: render
     gid: 104
+  # Ensure shared media group exist
+  - name: media
+    gid: 2000
+
+system_users:
+  # Ensure jellyfin user can access shared media
+  - name: jellyfin
+    groups:
+      - media
+    append: true

--- a/inventory/staging/host_vars/jellyfin/proxmox.yml
+++ b/inventory/staging/host_vars/jellyfin/proxmox.yml
@@ -12,6 +12,10 @@ proxmox_lxc:
   disk_volume:
     storage: "local-lvm"
     size: 16
+  mount_volumes:
+    mp0:
+      host_path: "/share"
+      mountpoint: "/mnt"
   cores: 2
   memory: 2048
   netif:
@@ -29,5 +33,12 @@ proxmox_lxc:
   features:
     - "keyctl=1"
     - "nesting=1"
+  raw_config:
+    - "lxc.idmap: u 0 100000 65536"
+    - "lxc.idmap: g 0 100000 2000"
+    - "lxc.idmap: g 2000 2000 1"
+    - "lxc.idmap: g 2001 102001 63535"
+  subgid:
+    - "root:2000:1"
   tags:
     - "media"

--- a/inventory/staging/host_vars/jellyfin/users.yml
+++ b/inventory/staging/host_vars/jellyfin/users.yml
@@ -1,0 +1,10 @@
+---
+system_groups:
+  - name: "shared_data"
+    gid: 2000
+
+system_users:
+  - name: "jellyfin"
+    groups:
+      - "shared_data"
+    append: true


### PR DESCRIPTION
This PR properly configures mapping a dedicated shared group from the Proxmox host to the Jellyfin LXC (the only one needing shared data so far). 

For the staging inventory, the shared group is named `shared_data`, while for production it is named `media`.